### PR TITLE
nix: add home-manager module

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -3,16 +3,20 @@
     nixpkgs.url = "nixpkgs/nixos-unstable";
   };
 
-  outputs = { self, nixpkgs }: let
-    forEachSystem = fn: nixpkgs.lib.genAttrs
-      [ "x86_64-linux" "aarch64-linux" ]
+  outputs = {
+    self,
+    nixpkgs,
+  }: let
+    forEachSystem = fn:
+      nixpkgs.lib.genAttrs
+      ["x86_64-linux" "aarch64-linux"]
       (system: fn system nixpkgs.legacyPackages.${system});
   in {
     packages = forEachSystem (system: pkgs: rec {
       quickshell = pkgs.callPackage ./default.nix {
         gitRev = self.rev or self.dirtyRev;
       };
-      quickshell-nvidia = quickshell.override { nvidiaCompat = true; };
+      quickshell-nvidia = quickshell.override {nvidiaCompat = true;};
 
       default = quickshell;
       nvidia = quickshell-nvidia;
@@ -24,5 +28,7 @@
         inherit (self.packages.${system}) quickshell;
       };
     });
+
+    homeManagerModules.default = import ./hm-module.nix self;
   };
 }

--- a/hm-module.nix
+++ b/hm-module.nix
@@ -1,0 +1,73 @@
+self: {
+  config,
+  pkgs,
+  lib,
+  ...
+}: let
+  # ALWAYS acquire the relevant functions from the appropriate parent attribute in lib.
+  # if I see even ONE with lib; or `inherit (lib)` in this module SO HELP ME GOD you will
+  # be defenestrated using a battle ram and I will piss on your grave
+  # - raf
+  inherit (lib.modules) mkIf;
+  inherit (lib.meta) getExe;
+  inherit (lib.types) nullOr listOf package str;
+  inherit (lib.options) mkOption mkEnableOption literalExpression;
+
+  defaultPackage = self.packages.${pkgs.stdenv.hostPlatform.system}.default;
+  cfg = config.programs.quickshell;
+in {
+  options.programs.quickshell = {
+    enable = mkEnableOption "quickshell";
+
+    package = mkOption {
+      type = nullOr package;
+      default = defaultPackage;
+      defaultText = literalExpression "inputs.quickshell.packages.${pkgs.stdenv.hostPlatform.system}.default";
+      description = ''
+        The quickshell package to use.
+
+        By default, this option will use the `packages.default` as exposed by this flake.
+      '';
+    };
+
+    runtimeDependencies = mkOption {
+      type = listOf package;
+      default = [];
+      description = ''
+        Additional runtime dependencies for quickshell.
+      '';
+    };
+
+    systemdTarget = mkOption {
+      type = str;
+      default = "graphical-session.target";
+      example = "sway-session.target";
+      description = ''
+        Systemd target to bind to.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [cfg.Package];
+
+    systemd.user.services.quickshell = {
+      Install.WantedBy = [cfg.systemdTarget];
+
+      Unit = {
+        Description = "quickshell";
+        After = ["graphical-session-pre.target"];
+        PartOf = [
+          "tray.target"
+          "graphical-session.target"
+        ];
+      };
+
+      Service = {
+        Type = "simple";
+        ExecStart = "${getExe cfg.package}";
+        Environment = "PATH=/run/wrappers/bin:${lib.makeBinPath cfg.runtimeDependencies}";
+      };
+    };
+  };
+}


### PR DESCRIPTION
- Formats the flake with `alejandra` (nixfmt users can fuck a hat)
- Adds a home-manager module