### PR TITLE
cli: add `callJson` ipc subcommand

### DIFF
--- a/src/launch/command.cpp
+++ b/src/launch/command.cpp
@@ -295,6 +295,13 @@ int ipcCommand(CommandState& cmd) {
 			return qs::io::ipc::comm::queryMetadata(&client, *cmd.ipc.target, *cmd.ipc.name);
 		} else if (*cmd.ipc.getprop) {
 			return qs::io::ipc::comm::getProperty(&client, *cmd.ipc.target, *cmd.ipc.name);
+		} else if (*cmd.ipc.callJson) {
+			return qs::io::ipc::comm::callFunction(
+			    &client,
+			    *cmd.ipc.target,
+			    *cmd.ipc.name,
+			    {*cmd.ipc.jsonArgument}
+			);
 		} else {
 			QVector<QString> arguments;
 			for (auto& arg: cmd.ipc.arguments) {

--- a/src/launch/launch_p.hpp
+++ b/src/launch/launch_p.hpp
@@ -71,10 +71,12 @@ struct CommandState {
 		CLI::App* ipc = nullptr;
 		CLI::App* show = nullptr;
 		CLI::App* call = nullptr;
+		CLI::App* callJson = nullptr;
 		CLI::App* getprop = nullptr;
 		bool showOld = false;
 		QStringOption target;
 		QStringOption name;
+		QStringOption jsonArgument;
 		std::vector<QStringOption> arguments;
 	} ipc;
 

--- a/src/launch/parsecommand.cpp
+++ b/src/launch/parsecommand.cpp
@@ -196,6 +196,22 @@ int parseCommand(int argc, char** argv, CommandState& state) {
 		}
 
 		{
+			auto* callJson = sub->add_subcommand(
+			    "callJson",
+			    "Call an IpcHandler function with a single JSON argument."
+			);
+			state.ipc.callJson = callJson;
+
+			callJson->add_option("target", state.ipc.target, "The target to message.");
+
+			callJson->add_option("function", state.ipc.name)
+			    ->description("The function to call in the target.");
+
+			callJson->add_option("json", state.ipc.jsonArgument)
+			    ->description("JSON string sent the called function.");
+		}
+
+		{
 			auto* prop =
 			    sub->add_subcommand("prop", "Manipulate IpcHandler properties.")->require_subcommand();
 


### PR DESCRIPTION
The `arguments` parser for the `ipc call` subcommand `allow_extra_args` does not gracefully handle many JSON strings. It will allow '{"hello": "world"}', but it will strip out square brackets and split the JSON string on commas, among other issues.

This is worked around by adding a new `callJson` ipc subcommand which accepts one string argument which is passed directly to the ipc call.

I understand that this is kind of hacky, and am open to modify this or taking a different approach. I do think something should be done for JSON because it can be somewhat frustrating to debug/learn when simple cases work but complex cases fail. At the very least I could ditch this change and update the documentation for `arguments`.