### PR TITLE
services/pipewire: expose type of node

### DIFF
--- a/src/services/pipewire/defaults.cpp
+++ b/src/services/pipewire/defaults.cpp
@@ -146,7 +146,7 @@ void PwDefaultTracker::onNodeDestroyed(QObject* node) {
 
 void PwDefaultTracker::changeConfiguredSink(PwNode* node) {
 	if (node != nullptr) {
-		if (!node->isSink) {
+		if (!node->type.testFlags(PwNodeType::AudioSink)) {
 			qCCritical(logDefaults) << "Cannot change default sink to a node that is not a sink.";
 			return;
 		}
@@ -168,7 +168,7 @@ void PwDefaultTracker::changeConfiguredSinkName(const QString& sink) {
 
 void PwDefaultTracker::changeConfiguredSource(PwNode* node) {
 	if (node != nullptr) {
-		if (node->isSink) {
+		if (!node->type.testFlags(PwNodeType::AudioSource)) {
 			qCCritical(logDefaults) << "Cannot change default source to a node that is not a source.";
 			return;
 		}

--- a/src/services/pipewire/node.cpp
+++ b/src/services/pipewire/node.cpp
@@ -11,6 +11,7 @@
 #include <qlogging.h>
 #include <qloggingcategory.h>
 #include <qobject.h>
+#include <qstringliteral.h>
 #include <qtmetamacros.h>
 #include <qtypes.h>
 #include <spa/node/keys.h>
@@ -85,6 +86,20 @@ QString PwAudioChannel::toString(Enum value) {
 	}
 }
 
+QString PwNodeType::toString(PwNodeType::Flags type) {
+	switch (type) {
+	case PwNodeType::VideoSource: return QStringLiteral("VideoSource");
+	case PwNodeType::VideoSink: return QStringLiteral("VideoSink");
+	case PwNodeType::AudioSource: return QStringLiteral("AudioSource");
+	case PwNodeType::AudioSink: return QStringLiteral("AudioSink");
+	case PwNodeType::AudioDuplex: return QStringLiteral("AudioDuplex");
+	case PwNodeType::AudioOutStream: return QStringLiteral("AudioOutStream");
+	case PwNodeType::AudioInStream: return QStringLiteral("AudioInStream");
+	case PwNodeType::Untracked: return QStringLiteral("Untracked");
+	default: return QStringLiteral("Invalid");
+	}
+}
+
 void PwNode::bindHooks() {
 	// Bind the device first as pw is in order, meaning the device should be bound before
 	// we want to do anything with it.
@@ -116,21 +131,19 @@ void PwNode::unbindHooks() {
 void PwNode::initProps(const spa_dict* props) {
 	if (const auto* mediaClass = spa_dict_lookup(props, SPA_KEY_MEDIA_CLASS)) {
 		if (strcmp(mediaClass, "Audio/Sink") == 0) {
-			this->type = PwNodeType::Audio;
-			this->isSink = true;
-			this->isStream = false;
+			this->type = PwNodeType::AudioSink;
 		} else if (strcmp(mediaClass, "Audio/Source") == 0) {
-			this->type = PwNodeType::Audio;
-			this->isSink = false;
-			this->isStream = false;
+			this->type = PwNodeType::AudioSource;
+		} else if (strcmp(mediaClass, "Audio/Duplex") == 0) {
+			this->type = PwNodeType::AudioDuplex;
 		} else if (strcmp(mediaClass, "Stream/Output/Audio") == 0) {
-			this->type = PwNodeType::Audio;
-			this->isSink = false;
-			this->isStream = true;
+			this->type = PwNodeType::AudioOutStream;
 		} else if (strcmp(mediaClass, "Stream/Input/Audio") == 0) {
-			this->type = PwNodeType::Audio;
-			this->isSink = true;
-			this->isStream = true;
+			this->type = PwNodeType::AudioInStream;
+		} else if (strcmp(mediaClass, "Video/Sink") == 0) {
+			this->type = PwNodeType::VideoSink;
+		} else if (strcmp(mediaClass, "Video/Source") == 0) {
+			this->type = PwNodeType::VideoSource;
 		}
 	}
 
@@ -164,7 +177,7 @@ void PwNode::initProps(const spa_dict* props) {
 		}
 	}
 
-	if (this->type == PwNodeType::Audio) {
+	if (this->type.testFlags(PwNodeType::Audio)) {
 		this->boundData = new PwNodeBoundAudio(this);
 	}
 }

--- a/src/services/pipewire/qml.cpp
+++ b/src/services/pipewire/qml.cpp
@@ -328,11 +328,13 @@ QString PwNodeIface::description() const { return this->mNode->description; }
 
 QString PwNodeIface::nickname() const { return this->mNode->nick; }
 
-bool PwNodeIface::isSink() const { return this->mNode->isSink; }
+bool PwNodeIface::isSink() const { return this->mNode->type.testFlags(PwNodeType::Sink); }
 
-bool PwNodeIface::isStream() const { return this->mNode->isStream; }
+bool PwNodeIface::isStream() const { return this->mNode->type.testFlags(PwNodeType::Stream); }
 
 bool PwNodeIface::isReady() const { return this->mNode->ready; }
+
+PwNodeType::Flags PwNodeIface::type() const { return this->mNode->type; };
 
 QVariantMap PwNodeIface::properties() const {
 	auto map = QVariantMap();

--- a/src/services/pipewire/qml.hpp
+++ b/src/services/pipewire/qml.hpp
@@ -287,6 +287,8 @@ class PwNodeIface: public PwObjectIface {
 	/// If `true` then the node is likely to be a program, if `false` it is likely to be
 	/// a hardware device.
 	Q_PROPERTY(bool isStream READ isStream CONSTANT);
+	/// The type of this node. Reflects Pipewire's [media.class](https://docs.pipewire.org/page_man_pipewire-props_7.html).
+	Q_PROPERTY(qs::service::pipewire::PwNodeType::Flags type READ type CONSTANT);
 	/// The property set present on the node, as an object containing key-value pairs.
 	/// You can inspect this directly with `pw-cli i <id>`.
 	///
@@ -324,6 +326,7 @@ public:
 	[[nodiscard]] bool isSink() const;
 	[[nodiscard]] bool isStream() const;
 	[[nodiscard]] bool isReady() const;
+	[[nodiscard]] PwNodeType::Flags type() const;
 	[[nodiscard]] QVariantMap properties() const;
 	[[nodiscard]] PwNodeAudioIface* audio() const;
 


### PR DESCRIPTION
I wanted to expose the node type, as a first effort to be able to implement a privacy indicator (usage of microphone/camera/screenshare).

