### PR TITLE
core/desktopentry: add file system watcher for desktop entry directories

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -23,6 +23,7 @@ qt_add_library(quickshell-core STATIC
 	model.cpp
 	elapsedtimer.cpp
 	desktopentry.cpp
+	desktopentrymonitor.cpp
 	objectrepeater.cpp
 	platformmenu.cpp
 	qsmenu.cpp

--- a/src/core/desktopentrymonitor.cpp
+++ b/src/core/desktopentrymonitor.cpp
@@ -1,0 +1,68 @@
+#include "desktopentrymonitor.hpp"
+
+#include <qdir.h>
+#include <qfileinfo.h>
+#include <qfilesystemwatcher.h>
+#include <qobject.h>
+#include <qstring.h>
+#include <qtmetamacros.h>
+
+#include "desktopentry.hpp"
+
+namespace {
+void addPathAndParents(QFileSystemWatcher& watcher, const QString& path) {
+	watcher.addPath(path);
+
+	auto p = QFileInfo(path).absolutePath();
+	while (!p.isEmpty()) {
+		watcher.addPath(p);
+		const auto parent = QFileInfo(p).dir().absolutePath();
+		if (parent == p) break;
+		p = parent;
+	}
+}
+} // namespace
+
+DesktopEntryMonitor::DesktopEntryMonitor(QObject* parent): QObject(parent) {
+	this->debounceTimer.setSingleShot(true);
+	this->debounceTimer.setInterval(100);
+
+	QObject::connect(
+	    &this->watcher,
+	    &QFileSystemWatcher::directoryChanged,
+	    this,
+	    &DesktopEntryMonitor::onDirectoryChanged
+	);
+	QObject::connect(
+	    &this->debounceTimer,
+	    &QTimer::timeout,
+	    this,
+	    &DesktopEntryMonitor::processChanges
+	);
+
+	this->startMonitoring();
+}
+
+void DesktopEntryMonitor::startMonitoring() {
+	for (const auto& path: DesktopEntryManager::desktopPaths()) {
+		if (!QDir(path).exists()) continue;
+		addPathAndParents(this->watcher, path);
+		this->scanAndWatch(path);
+	}
+}
+
+void DesktopEntryMonitor::scanAndWatch(const QString& dirPath) {
+	auto dir = QDir(dirPath);
+	if (!dir.exists()) return;
+
+	this->watcher.addPath(dirPath);
+
+	auto subdirs = dir.entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot | QDir::NoSymLinks);
+	for (const auto& subdir: subdirs) this->watcher.addPath(subdir.absoluteFilePath());
+}
+
+void DesktopEntryMonitor::onDirectoryChanged(const QString& /*path*/) {
+	this->debounceTimer.start();
+}
+
+void DesktopEntryMonitor::processChanges() { emit this->desktopEntriesChanged(); }

--- a/src/core/desktopentrymonitor.hpp
+++ b/src/core/desktopentrymonitor.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <qfilesystemwatcher.h>
+#include <qobject.h>
+#include <qstringlist.h>
+#include <qtimer.h>
+
+class DesktopEntryMonitor: public QObject {
+	Q_OBJECT
+
+public:
+	explicit DesktopEntryMonitor(QObject* parent = nullptr);
+	~DesktopEntryMonitor() override = default;
+	DesktopEntryMonitor(const DesktopEntryMonitor&) = delete;
+	DesktopEntryMonitor& operator=(const DesktopEntryMonitor&) = delete;
+	DesktopEntryMonitor(DesktopEntryMonitor&&) = delete;
+	DesktopEntryMonitor& operator=(DesktopEntryMonitor&&) = delete;
+
+signals:
+	void desktopEntriesChanged();
+
+private slots:
+	void onDirectoryChanged(const QString& path);
+	void processChanges();
+
+private:
+	void startMonitoring();
+	void scanAndWatch(const QString& dirPath);
+
+	QFileSystemWatcher watcher;
+	QTimer debounceTimer;
+};

--- a/src/services/notifications/notification.cpp
+++ b/src/services/notifications/notification.cpp
@@ -127,7 +127,7 @@ void Notification::updateProperties(
 
 	if (appIcon.isEmpty() && !this->bDesktopEntry.value().isEmpty()) {
 		if (auto* entry = DesktopEntryManager::instance()->byId(this->bDesktopEntry.value())) {
-			appIcon = entry->mIcon;
+			appIcon = entry->bIcon.value();
 		}
 	}
 


### PR DESCRIPTION
DesktopEntries only scans one time~~, and doesnt expose scanning functions to QML. This adds a `rescan` function, a signal for applications changed. It just allows a nicer launcher that doesn't get stale.~~

This adds:
- `DesktopUtils` which had a common function for locating `.desktop` files
- `DesktopEntryMonitor` which implements [QFileSystemWatcher](https://doc.qt.io/qt-6/qfilesystemwatcher.html)
  - Watches the desktop entry target directories
- Connect monitor to `DesktopEntryManager` and add a new signal `applicationsChanged`
  - On directory updated, it re-fetches the entries and emits the signal

