### PR TITLE
services/pipewire: defer onNodeDestroyed signals to prevent crash

### DIFF
--- a/src/services/pipewire/defaults.cpp
+++ b/src/services/pipewire/defaults.cpp
@@ -126,25 +126,33 @@ void PwDefaultTracker::onNodeDestroyed(QObject* node) {
 	if (node == this->mDefaultSink) {
 		qCInfo(logDefaults) << "Default sink destroyed.";
 		this->mDefaultSink = nullptr;
-		emit this->defaultSinkChanged();
+		QMetaObject::invokeMethod(this, &PwDefaultTracker::defaultSinkChanged, Qt::QueuedConnection);
 	}
 
 	if (node == this->mDefaultSource) {
 		qCInfo(logDefaults) << "Default source destroyed.";
 		this->mDefaultSource = nullptr;
-		emit this->defaultSourceChanged();
+		QMetaObject::invokeMethod(this, &PwDefaultTracker::defaultSourceChanged, Qt::QueuedConnection);
 	}
 
 	if (node == this->mDefaultConfiguredSink) {
 		qCInfo(logDefaults) << "Default configured sink destroyed.";
 		this->mDefaultConfiguredSink = nullptr;
-		emit this->defaultConfiguredSinkChanged();
+		QMetaObject::invokeMethod(
+		    this,
+		    &PwDefaultTracker::defaultConfiguredSinkChanged,
+		    Qt::QueuedConnection
+		);
 	}
 
 	if (node == this->mDefaultConfiguredSource) {
 		qCInfo(logDefaults) << "Default configured source destroyed.";
 		this->mDefaultConfiguredSource = nullptr;
-		emit this->defaultConfiguredSourceChanged();
+		QMetaObject::invokeMethod(
+		    this,
+		    &PwDefaultTracker::defaultConfiguredSourceChanged,
+		    Qt::QueuedConnection
+		);
 	}
 }
 
@@ -201,7 +209,8 @@ bool PwDefaultTracker::setConfiguredDefault(const char* key, const QString& valu
 	}
 
 	if (!meta->hasSetPermission()) {
-		qCCritical(logDefaults
+		qCCritical(
+		    logDefaults
 		) << "Cannot set default node as write+execute permissions are missing for"
 		  << meta;
 		return false;


### PR DESCRIPTION
On resume was getting crashes like this:

```
#23 0x000055d9143f6271 _ZN2qs7service8pipewire16PwDefaultTracker15onNodeDestroyedEP7QObject
#0  0x0000562eb464d110 _ZN17QArrayDataPointerIDsEC4ERKS0_ (std::_Rb_tree corruption)
Jul 16 08:58:58 arch systemd-coredump[116918]: Process 116915 (quickshell) of user 1000 dumped core.
```

This should defer the `onNodeDestroyed` signals until the next event loop iteration, I havent been able to re-create the crash since implementing this change.