### PR TITLE
services/tray: use normal icon as fallback for attention custom icon

### DIFF
--- a/src/services/status_notifier/item.cpp
+++ b/src/services/status_notifier/item.cpp
@@ -163,6 +163,10 @@ QPixmap StatusNotifierItem::createPixmap(const QSize& size) const {
 		} else {
 			const auto* icon = closestPixmap(size, this->bAttentionIconPixmaps.value());
 
+			if (icon == nullptr) {
+				icon = closestPixmap(size, this->bIconPixmaps.value());
+			}
+
 			if (icon != nullptr) {
 				const auto image =
 				    icon->createImage().scaled(size, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);


### PR DESCRIPTION
When selecting an SNI icon pixmap, if there are no custom icon pixmaps for attentionIcon, try a regular custom icon pixmap as well.

### The problem
Some apps with custom (non-theme) icons set their SNI status to NeedsAttention, but send their icon pixmaps as IconPixmap instead of AttentionIconPixmap. Currently, this situation results in no icon being chosen.

An example of such app is [Amnezia VPN](https://github.com/amnezia-vpn/amnezia-client), but I think there are a lot more, since both the GNOME AppIndicator extension and Waybar support this (more on that in Rationale).

The proposed solution here (this PR) is to try and set the normal custom icon in case no attentionIcon pixmaps are found.

### Rationale/Justification
- this solution doesn't break or modify existing logic, instead just providing a fallback in a situation that would otherwise result in a missing icon
- users have no way of handling this situation separately, since the custom pixmaps are not available in the QML API
- [This is what the official GNOME AppIndicator extension does](https://github.com/ubuntu/gnome-shell-extension-appindicator/blob/acc9e790f6f35992fc8b3570e6b15f8877c4815d/appIndicator.js#L1414)
- [This is **kind of** what Waybar does](https://github.com/Alexays/Waybar/blob/94777921d96c2657c37c7d83a18f13968df486de/src/modules/sni/item.cpp#L162) - in Waybar custom AttentionIcon pixmaps are not implemented, so it uses the normal icon anyway

#### Note:
Waybar also doesn't implement custom OverlayIcon pixmaps, whereas the GNOME AppIndicator extension specifically doesn't apply this fallback to icons with type Overlay. I think that the GNOME AppIndicator implementation should be considered more mature/competent as a reference, so this fallback is also only implemented for Attention icons.