### PR TITLE
bluetooth: add rssi property

### DIFF
--- a/src/bluetooth/device.cpp
+++ b/src/bluetooth/device.cpp
@@ -56,23 +56,22 @@ BluetoothAdapter* BluetoothDevice::adapter() const {
 }
 
 qint32 BluetoothDevice::signalStrength() const {
-	if (this->bRssi.value() == 0) return 0;
+	const auto rssi = this->bRssi.value();
+	auto percent = 0.0;
 
-	auto rssi = std::clamp(static_cast<double>(this->bRssi.value()), -100.0, -30.0);
+	if (rssi == 0) {
+		percent = 0.0;
+	} else if (rssi >= -30) {
+		percent = 100.0;
+	} else if (rssi >= -60) {
+		percent = 75.0 + ((rssi + 60.0) / 30.0) * 25.0;
+	} else if (rssi >= -80) {
+		percent = 9.0 + ((rssi + 80.0) / 20.0) * 66.0;
+	} else if (rssi >= -90) {
+		percent = ((rssi + 90.0) / 10.0) * 9.0;
+	}
 
-	if (rssi >= -60.0) {
-		auto percentage = 75.0 + ((rssi + 60.0) / 30.0) * 25.0;
-		return static_cast<qint32>(std::round(percentage));
-	}
-	if (rssi >= -80.0) {
-		auto percentage = 9.0 + ((rssi + 80.0) / 20.0) * 66.0;
-		return static_cast<qint32>(std::round(percentage));
-	}
-	if (rssi >= -90.0) {
-		auto percentage = 0.0 + ((rssi + 90.0) / 10.0) * 9.0;
-		return static_cast<qint32>(std::round(percentage));
-	}
-	return 0;
+	return static_cast<qint32>(std::lround(std::clamp(percent, 0.0, 100.0)));
 }
 
 void BluetoothDevice::setConnected(bool connected) {

--- a/src/bluetooth/device.hpp
+++ b/src/bluetooth/device.hpp
@@ -99,9 +99,8 @@ class BluetoothDevice: public QObject {
 	Q_PROPERTY(bool batteryAvailable READ batteryAvailable NOTIFY batteryAvailableChanged);
 	/// Battery level of the connected device, from `0.0` to `1.0`. Only valid if @@batteryAvailable is true.
 	Q_PROPERTY(qreal battery READ default NOTIFY batteryChanged BINDABLE bindableBattery);
-	/// Received Signal Strength Indicator in dBm. Only valid when device is discoverable/advertising.
-	/// Typical values range from -30 (very close) to -90 (far away). Values of 0 indicate no signal data.
-	Q_PROPERTY(qint16 rssi READ rssi NOTIFY rssiChanged BINDABLE bindableRssi);
+	/// Signal strength as a normalized score from 0 to 100, where higher is better (stronger signal).
+	Q_PROPERTY(qint32 signalStrength READ signalStrength NOTIFY signalStrengthChanged BINDABLE bindableSignalStrength);
 	/// The Bluetooth adapter this device belongs to.
 	Q_PROPERTY(BluetoothAdapter* adapter READ adapter NOTIFY adapterChanged);
 	/// DBus path of the device under the `org.bluez` system service.
@@ -148,7 +147,7 @@ public:
 	[[nodiscard]] bool wakeAllowed() const { return this->bWakeAllowed; }
 	void setWakeAllowed(bool wakeAllowed);
 
-	[[nodiscard]] qint16 rssi() const { return this->bRssi; }
+	[[nodiscard]] qint32 signalStrength() const;
 
 	[[nodiscard]] bool pairing() const { return this->bPairing; }
 
@@ -164,7 +163,7 @@ public:
 	[[nodiscard]] QBindable<QString> bindableIcon() { return &this->bIcon; }
 	[[nodiscard]] QBindable<qreal> bindableBattery() { return &this->bBattery; }
 	[[nodiscard]] QBindable<BluetoothDeviceState::Enum> bindableState() { return &this->bState; }
-	[[nodiscard]] QBindable<qint16> bindableRssi() { return &this->bRssi; }
+	[[nodiscard]] QBindable<qint32> bindableSignalStrength() { return &this->bSignalStrength; }
 
 	void addInterface(const QString& interface, const QVariantMap& properties);
 	void removeInterface(const QString& interface);
@@ -184,7 +183,7 @@ signals:
 	void iconChanged();
 	void batteryAvailableChanged();
 	void batteryChanged();
-	void rssiChanged();
+	void signalStrengthChanged();
 	void adapterChanged();
 
 private:
@@ -208,7 +207,8 @@ private:
 	Q_OBJECT_BINDABLE_PROPERTY(BluetoothDevice, qreal, bBattery, &BluetoothDevice::batteryChanged);
 	Q_OBJECT_BINDABLE_PROPERTY(BluetoothDevice, BluetoothDeviceState::Enum, bState, &BluetoothDevice::stateChanged);
 	Q_OBJECT_BINDABLE_PROPERTY(BluetoothDevice, bool, bPairing, &BluetoothDevice::pairingChanged);
-	Q_OBJECT_BINDABLE_PROPERTY(BluetoothDevice, qint16, bRssi, &BluetoothDevice::rssiChanged);
+	Q_OBJECT_BINDABLE_PROPERTY(BluetoothDevice, qint32, bSignalStrength, &BluetoothDevice::signalStrengthChanged);
+	Q_OBJECT_BINDABLE_PROPERTY(BluetoothDevice, qint16, bRssi);
 
 	QS_DBUS_BINDABLE_PROPERTY_GROUP(BluetoothDevice, properties);
 	QS_DBUS_PROPERTY_BINDING(BluetoothDevice, pAddress, bAddress, properties, "Address");

--- a/src/bluetooth/device.hpp
+++ b/src/bluetooth/device.hpp
@@ -99,6 +99,9 @@ class BluetoothDevice: public QObject {
 	Q_PROPERTY(bool batteryAvailable READ batteryAvailable NOTIFY batteryAvailableChanged);
 	/// Battery level of the connected device, from `0.0` to `1.0`. Only valid if @@batteryAvailable is true.
 	Q_PROPERTY(qreal battery READ default NOTIFY batteryChanged BINDABLE bindableBattery);
+	/// Received Signal Strength Indicator in dBm. Only valid when device is discoverable/advertising.
+	/// Typical values range from -30 (very close) to -90 (far away). Values of 0 indicate no signal data.
+	Q_PROPERTY(qint16 rssi READ rssi NOTIFY rssiChanged BINDABLE bindableRssi);
 	/// The Bluetooth adapter this device belongs to.
 	Q_PROPERTY(BluetoothAdapter* adapter READ adapter NOTIFY adapterChanged);
 	/// DBus path of the device under the `org.bluez` system service.
@@ -145,6 +148,8 @@ public:
 	[[nodiscard]] bool wakeAllowed() const { return this->bWakeAllowed; }
 	void setWakeAllowed(bool wakeAllowed);
 
+	[[nodiscard]] qint16 rssi() const { return this->bRssi; }
+
 	[[nodiscard]] bool pairing() const { return this->bPairing; }
 
 	[[nodiscard]] QBindable<QString> bindableAddress() { return &this->bAddress; }
@@ -159,6 +164,7 @@ public:
 	[[nodiscard]] QBindable<QString> bindableIcon() { return &this->bIcon; }
 	[[nodiscard]] QBindable<qreal> bindableBattery() { return &this->bBattery; }
 	[[nodiscard]] QBindable<BluetoothDeviceState::Enum> bindableState() { return &this->bState; }
+	[[nodiscard]] QBindable<qint16> bindableRssi() { return &this->bRssi; }
 
 	void addInterface(const QString& interface, const QVariantMap& properties);
 	void removeInterface(const QString& interface);
@@ -178,6 +184,7 @@ signals:
 	void iconChanged();
 	void batteryAvailableChanged();
 	void batteryChanged();
+	void rssiChanged();
 	void adapterChanged();
 
 private:
@@ -201,6 +208,7 @@ private:
 	Q_OBJECT_BINDABLE_PROPERTY(BluetoothDevice, qreal, bBattery, &BluetoothDevice::batteryChanged);
 	Q_OBJECT_BINDABLE_PROPERTY(BluetoothDevice, BluetoothDeviceState::Enum, bState, &BluetoothDevice::stateChanged);
 	Q_OBJECT_BINDABLE_PROPERTY(BluetoothDevice, bool, bPairing, &BluetoothDevice::pairingChanged);
+	Q_OBJECT_BINDABLE_PROPERTY(BluetoothDevice, qint16, bRssi, &BluetoothDevice::rssiChanged);
 
 	QS_DBUS_BINDABLE_PROPERTY_GROUP(BluetoothDevice, properties);
 	QS_DBUS_PROPERTY_BINDING(BluetoothDevice, pAddress, bAddress, properties, "Address");
@@ -214,6 +222,7 @@ private:
 	QS_DBUS_PROPERTY_BINDING(BluetoothDevice, pWakeAllowed, bWakeAllowed, properties, "WakeAllowed");
 	QS_DBUS_PROPERTY_BINDING(BluetoothDevice, pIcon, bIcon, properties, "Icon");
 	QS_DBUS_PROPERTY_BINDING(BluetoothDevice, pAdapterPath, bAdapterPath, properties, "Adapter");
+	QS_DBUS_PROPERTY_BINDING(BluetoothDevice, pRssi, bRssi, properties, "RSSI", true);
 
 	QS_DBUS_BINDABLE_PROPERTY_GROUP(BluetoothDevice, batteryProperties);
 	QS_DBUS_PROPERTY_BINDING(BluetoothDevice, BatteryPercentage, pBattery, bBattery, batteryProperties, "Percentage", true);

--- a/src/bluetooth/device.hpp
+++ b/src/bluetooth/device.hpp
@@ -222,7 +222,7 @@ private:
 	QS_DBUS_PROPERTY_BINDING(BluetoothDevice, pWakeAllowed, bWakeAllowed, properties, "WakeAllowed");
 	QS_DBUS_PROPERTY_BINDING(BluetoothDevice, pIcon, bIcon, properties, "Icon");
 	QS_DBUS_PROPERTY_BINDING(BluetoothDevice, pAdapterPath, bAdapterPath, properties, "Adapter");
-	QS_DBUS_PROPERTY_BINDING(BluetoothDevice, pRssi, bRssi, properties, "RSSI", true);
+	QS_DBUS_PROPERTY_BINDING(BluetoothDevice, pRssi, bRssi, properties, "RSSI", false);
 
 	QS_DBUS_BINDABLE_PROPERTY_GROUP(BluetoothDevice, batteryProperties);
 	QS_DBUS_PROPERTY_BINDING(BluetoothDevice, BatteryPercentage, pBattery, bBattery, batteryProperties, "Percentage", true);


### PR DESCRIPTION
Add rssi to bluetooth property bindings. It's useful to see signal strength of devices during discovery (IE, for sorting by signal strength, ignoring very low signal strength devices)

Because rssi is not available when the adapter is no longer discovering I also added a condition to lower the log level on the property update callback for optional properties, it's not really necessary and can be removed - but prevents some log spam when  turning off discovery (because the rssi properties become unavailable)