### PR TITLE
core/itemimagegrab: `ItemImageGrab` component

### DIFF
--- a/src/core/instanceinfo.hpp
+++ b/src/core/instanceinfo.hpp
@@ -6,6 +6,14 @@
 #include <sys/types.h>
 
 struct InstanceInfo {
+	Q_GADGET
+
+	Q_PROPERTY(QString instanceId MEMBER instanceId CONSTANT)
+	Q_PROPERTY(QString shellId MEMBER shellId CONSTANT)
+	Q_PROPERTY(QString appId MEMBER appId CONSTANT)
+	Q_PROPERTY(QDateTime launchTime MEMBER launchTime CONSTANT)
+
+public:
 	QString instanceId;
 	QString configPath;
 	QString shellId;

--- a/src/core/qmlglobal.cpp
+++ b/src/core/qmlglobal.cpp
@@ -154,8 +154,8 @@ qint32 QuickshellGlobal::processId() const { // NOLINT
 	return getpid();
 }
 
-QString QuickshellGlobal::instanceId() const { // NOLINT
-	return InstanceInfo::CURRENT.instanceId;
+InstanceInfo QuickshellGlobal::instanceInfo() const { // NOLINT
+	return InstanceInfo::CURRENT;
 }
 
 qsizetype QuickshellGlobal::screensCount(QQmlListProperty<QuickshellScreenInfo>* /*unused*/) {

--- a/src/core/qmlglobal.hpp
+++ b/src/core/qmlglobal.hpp
@@ -17,6 +17,7 @@
 
 #include "../io/processcore.hpp"
 #include "doc.hpp"
+#include "instanceinfo.hpp"
 #include "qmlscreen.hpp"
 
 ///! Accessor for some options under the Quickshell type.
@@ -83,8 +84,8 @@ class QuickshellGlobal: public QObject {
 	// clang-format off
 	/// Quickshell's process id.
 	Q_PROPERTY(qint32 processId READ processId CONSTANT);
-	/// The id of the current shell instance.
-	Q_PROPERTY(QString instanceId READ instanceId CONSTANT);
+	/// Information about the current instance of Quickshell.
+	Q_PROPERTY(InstanceInfo instanceInfo READ instanceInfo CONSTANT);
 	/// All currently connected screens.
 	///
 	/// This property updates as connected screens change.
@@ -151,7 +152,7 @@ class QuickshellGlobal: public QObject {
 
 public:
 	[[nodiscard]] qint32 processId() const;
-	[[nodiscard]] QString instanceId() const;
+	[[nodiscard]] InstanceInfo instanceInfo() const;
 
 	QQmlListProperty<QuickshellScreenInfo> screens();
 


### PR DESCRIPTION
Adds a custom QML component `ItemImageGrab` which can be used to grab and save items to an image file. The component provides 2 methods each with 2 overloads, `grab` and `cropAndGrab`.

`grab` is for grabbing and saving an item to a file asynchronously, while `cropAndGrab` does the same but allows cropping to a specific size when saving.