### PR TITLE
bluetooth: implement pairing agent

### DIFF
--- a/src/bluetooth/CMakeLists.txt
+++ b/src/bluetooth/CMakeLists.txt
@@ -6,6 +6,10 @@ set_source_files_properties(org.bluez.Device.xml PROPERTIES
 	CLASSNAME DBusBluezDeviceInterface
 )
 
+set_source_files_properties(org.bluez.AgentManager.xml PROPERTIES
+	CLASSNAME DBusBluezAgentManagerInterface
+)
+
 qt_add_dbus_interface(DBUS_INTERFACES
 	org.bluez.Adapter.xml
 	dbus_adapter
@@ -16,11 +20,25 @@ qt_add_dbus_interface(DBUS_INTERFACES
 	dbus_device
 )
 
+qt_add_dbus_interface(DBUS_INTERFACES
+	org.bluez.AgentManager.xml
+	dbus_agent_manager
+)
+
+qt_add_dbus_adaptor(DBUS_ADAPTORS
+	org.bluez.Agent.xml
+	agent.hpp
+	qs::bluetooth::BluetoothAgent
+	dbus_agent_adaptor
+)
+
 qt_add_library(quickshell-bluetooth STATIC
 	adapter.cpp
+	agent.cpp
 	bluez.cpp
 	device.cpp
 	${DBUS_INTERFACES}
+	${DBUS_ADAPTORS}
 )
 
 qt_add_qml_module(quickshell-bluetooth

--- a/src/bluetooth/adapter.cpp
+++ b/src/bluetooth/adapter.cpp
@@ -44,6 +44,7 @@ BluetoothAdapter::BluetoothAdapter(const QString& path, QObject* parent): QObjec
 	}
 
 	this->properties.setInterface(this->mInterface);
+	this->properties.updateAllViaGetAll();
 }
 
 QString BluetoothAdapter::adapterId() const {

--- a/src/bluetooth/agent.cpp
+++ b/src/bluetooth/agent.cpp
@@ -1,12 +1,22 @@
 #include "agent.hpp"
+#include <atomic>
 
+#include <qdbusconnection.h>
+#include <qdbuserror.h>
 #include <qdbusextratypes.h>
 #include <qdebug.h>
 #include <qlogging.h>
 #include <qloggingcategory.h>
 #include <qstringliteral.h>
 
+#include "../core/logcat.hpp"
+
 namespace qs::bluetooth {
+
+namespace {
+QS_LOGGING_CATEGORY(logAgent, "quickshell.bluetooth.agent", QtWarningMsg);
+std::atomic<quint32> gTokenCounter {1};
+} // namespace
 
 BluetoothAgent::BluetoothAgent(QObject* parent)
     : QObject(parent)
@@ -14,15 +24,182 @@ BluetoothAgent::BluetoothAgent(QObject* parent)
 
 QString BluetoothAgent::objectPath() const { return this->mObjectPath; }
 
-void BluetoothAgent::RequestAuthorization(const QDBusObjectPath& device) { Q_UNUSED(device); }
+QString BluetoothAgent::getDeviceAddress(const QDBusObjectPath& device) {
+	auto path = device.path();
+	auto lastSlash = path.lastIndexOf('/');
 
-void BluetoothAgent::RequestConfirmation(const QDBusObjectPath& device, quint32 passkey) {
-	Q_UNUSED(device);
-	Q_UNUSED(passkey);
+	if (lastSlash >= 0) {
+		auto devicePart = path.mid(lastSlash + 1);
+
+		if (devicePart.startsWith("dev_")) {
+			auto macPart = devicePart.mid(4);
+			return macPart.replace('_', ':');
+		}
+	}
+
+	return path;
 }
 
-void BluetoothAgent::Cancel() {}
+void BluetoothAgent::enqueuePendingRequest(
+    const QDBusObjectPath& device,
+    BluetoothPairingRequestType::Enum type
+) {
+	auto msg = message();
+	PendingRequest request;
+	request.message = msg;
+	request.type = type;
+	request.devicePath = device.path();
+	request.serial = gTokenCounter.fetch_add(1);
 
-void BluetoothAgent::Release() {}
+	this->mPendingRequests.insert(request.serial, request);
+	this->mLastSerial = request.serial;
+	setDelayedReply(true);
+}
+
+void BluetoothAgent::RequestAuthorization(const QDBusObjectPath& device) {
+	qCDebug(logAgent) << "Authorization request for device" << device.path();
+	this->enqueuePendingRequest(device, BluetoothPairingRequestType::Authorization);
+	emit this->pairingRequested(
+	    getDeviceAddress(device),
+	    BluetoothPairingRequestType::Authorization,
+	    0,
+	    this->mLastSerial
+	);
+}
+
+void BluetoothAgent::RequestConfirmation(const QDBusObjectPath& device, quint32 passkey) {
+	qCDebug(logAgent) << "Confirmation request for device" << device.path() << "passkey" << passkey;
+	this->enqueuePendingRequest(device, BluetoothPairingRequestType::Confirmation);
+	emit this->pairingRequested(
+	    getDeviceAddress(device),
+	    BluetoothPairingRequestType::Confirmation,
+	    passkey,
+	    this->mLastSerial
+	);
+}
+
+void BluetoothAgent::AuthorizeService(const QDBusObjectPath& device, const QString& uuid) {
+	qCDebug(logAgent) << "Service authorization request for device" << device.path() << "uuid"
+	                  << uuid;
+	this->enqueuePendingRequest(device, BluetoothPairingRequestType::ServiceAuthorization);
+	emit this->pairingRequested(
+	    getDeviceAddress(device),
+	    BluetoothPairingRequestType::ServiceAuthorization,
+	    0,
+	    this->mLastSerial
+	);
+}
+
+void BluetoothAgent::RequestPinCode(const QDBusObjectPath& device) {
+	qCDebug(logAgent) << "PIN code request for device" << device.path();
+	this->enqueuePendingRequest(device, BluetoothPairingRequestType::PinCode);
+	emit this->pairingRequested(
+	    getDeviceAddress(device),
+	    BluetoothPairingRequestType::PinCode,
+	    0,
+	    this->mLastSerial
+	);
+}
+
+void BluetoothAgent::RequestPasskey(const QDBusObjectPath& device) {
+	qCDebug(logAgent) << "Passkey request for device" << device.path();
+	this->enqueuePendingRequest(device, BluetoothPairingRequestType::Passkey);
+	emit this->pairingRequested(
+	    getDeviceAddress(device),
+	    BluetoothPairingRequestType::Passkey,
+	    0,
+	    this->mLastSerial
+	);
+}
+
+void BluetoothAgent::DisplayPinCode(const QDBusObjectPath& device, const QString& pincode) {
+	qCDebug(logAgent) << "Display PIN code for device" << device.path() << "pincode" << pincode;
+	emit this->pairingRequested(getDeviceAddress(device), BluetoothPairingRequestType::PinCode, 0, 0);
+}
+
+void BluetoothAgent::DisplayPasskey(
+    const QDBusObjectPath& device,
+    quint32 passkey,
+    quint16 entered
+) {
+	qCDebug(logAgent) << "Display passkey for device" << device.path() << "passkey" << passkey
+	                  << "entered" << entered;
+	emit this->pairingRequested(
+	    getDeviceAddress(device),
+	    BluetoothPairingRequestType::Passkey,
+	    passkey,
+	    0
+	);
+}
+
+void BluetoothAgent::Cancel() {
+	qCDebug(logAgent) << "Agent operation cancelled";
+
+	if (this->mLastSerial != 0 && this->mPendingRequests.contains(this->mLastSerial)) {
+		qCDebug(logAgent) << "Cancelling most recent request serial" << this->mLastSerial;
+		this->mPendingRequests.remove(this->mLastSerial);
+	}
+}
+
+void BluetoothAgent::Release() {
+	qCDebug(logAgent) << "Agent released by BlueZ";
+
+	for (auto& request: this->mPendingRequests) {
+		auto reply = request.message.createErrorReply(QDBusError::NoReply, "Agent released");
+		QDBusConnection::systemBus().send(reply);
+	}
+
+	this->mPendingRequests.clear();
+	this->mLastSerial = 0;
+
+	emit this->agentReleased();
+}
+
+void BluetoothAgent::respondToRequest(quint32 token, bool accept) {
+	auto it = this->mPendingRequests.find(token);
+	if (it == this->mPendingRequests.end()) return;
+
+	auto request = it.value();
+	this->mPendingRequests.erase(it);
+
+	qCDebug(logAgent) << (accept ? "Accepting" : "Rejecting") << "request token" << token;
+
+	auto reply = accept ? request.message.createReply()
+	                    : request.message.createErrorReply(QDBusError::AccessDenied, "User rejected");
+
+	QDBusConnection::systemBus().send(reply);
+}
+
+void BluetoothAgent::respondWithPinCode(quint32 token, const QString& pinCode) {
+	auto it = this->mPendingRequests.find(token);
+	if (it == this->mPendingRequests.end() || it->type != BluetoothPairingRequestType::PinCode)
+		return;
+
+	auto request = it.value();
+	this->mPendingRequests.erase(it);
+
+	qCDebug(logAgent) << "Responding with PIN code:" << pinCode << "for token" << token;
+
+	auto reply = request.message.createReply();
+	reply << pinCode;
+
+	QDBusConnection::systemBus().send(reply);
+}
+
+void BluetoothAgent::respondWithPasskey(quint32 token, quint32 passkey) {
+	auto it = this->mPendingRequests.find(token);
+	if (it == this->mPendingRequests.end() || it->type != BluetoothPairingRequestType::Passkey)
+		return;
+
+	auto request = it.value();
+	this->mPendingRequests.erase(it);
+
+	qCDebug(logAgent) << "Responding with passkey:" << passkey << "for token" << token;
+
+	auto reply = request.message.createReply();
+	reply << passkey;
+
+	QDBusConnection::systemBus().send(reply);
+}
 
 } // namespace qs::bluetooth

--- a/src/bluetooth/agent.cpp
+++ b/src/bluetooth/agent.cpp
@@ -1,0 +1,28 @@
+#include "agent.hpp"
+
+#include <qdbusextratypes.h>
+#include <qdebug.h>
+#include <qlogging.h>
+#include <qloggingcategory.h>
+#include <qstringliteral.h>
+
+namespace qs::bluetooth {
+
+BluetoothAgent::BluetoothAgent(QObject* parent)
+    : QObject(parent)
+    , mObjectPath(QStringLiteral("/org/quickshell/bluetooth/agent")) {}
+
+QString BluetoothAgent::objectPath() const { return this->mObjectPath; }
+
+void BluetoothAgent::RequestAuthorization(const QDBusObjectPath& device) { Q_UNUSED(device); }
+
+void BluetoothAgent::RequestConfirmation(const QDBusObjectPath& device, quint32 passkey) {
+	Q_UNUSED(device);
+	Q_UNUSED(passkey);
+}
+
+void BluetoothAgent::Cancel() {}
+
+void BluetoothAgent::Release() {}
+
+} // namespace qs::bluetooth

--- a/src/bluetooth/agent.hpp
+++ b/src/bluetooth/agent.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <qdbusextratypes.h>
+#include <qobject.h>
+#include <qtmetamacros.h>
+
+namespace qs::bluetooth {
+
+class BluetoothAgent: public QObject {
+	Q_OBJECT;
+
+public:
+	explicit BluetoothAgent(QObject* parent = nullptr);
+
+	[[nodiscard]] QString objectPath() const;
+
+public Q_SLOTS:
+	void RequestAuthorization(const QDBusObjectPath& device);
+	void RequestConfirmation(const QDBusObjectPath& device, quint32 passkey);
+	void Cancel();
+	void Release();
+
+private:
+	QString mObjectPath;
+};
+
+} // namespace qs::bluetooth

--- a/src/bluetooth/agent.hpp
+++ b/src/bluetooth/agent.hpp
@@ -1,27 +1,75 @@
 #pragma once
 
+#include <qdbuscontext.h>
 #include <qdbusextratypes.h>
+#include <qdbusmessage.h>
+#include <qhash.h>
 #include <qobject.h>
+#include <qqmlintegration.h>
 #include <qtmetamacros.h>
 
 namespace qs::bluetooth {
 
-class BluetoothAgent: public QObject {
+class BluetoothPairingRequestType: public QObject {
 	Q_OBJECT;
+	QML_ELEMENT;
+	QML_UNCREATABLE("Enum type");
+
+public:
+	enum Enum { Authorization, Confirmation, PinCode, Passkey, ServiceAuthorization };
+	Q_ENUM(Enum);
+};
+
+class BluetoothAgent
+    : public QObject
+    , protected QDBusContext {
+	Q_OBJECT;
+	QML_ELEMENT;
 
 public:
 	explicit BluetoothAgent(QObject* parent = nullptr);
 
 	[[nodiscard]] QString objectPath() const;
 
-public Q_SLOTS:
+	Q_INVOKABLE void respondToRequest(quint32 token, bool accept);
+	Q_INVOKABLE void respondWithPinCode(quint32 token, const QString& pinCode);
+	Q_INVOKABLE void respondWithPasskey(quint32 token, quint32 passkey);
+
+	// NOLINTBEGIN
 	void RequestAuthorization(const QDBusObjectPath& device);
 	void RequestConfirmation(const QDBusObjectPath& device, quint32 passkey);
+	void AuthorizeService(const QDBusObjectPath& device, const QString& uuid);
+	void RequestPinCode(const QDBusObjectPath& device);
+	void RequestPasskey(const QDBusObjectPath& device);
+	void DisplayPinCode(const QDBusObjectPath& device, const QString& pincode);
+	void DisplayPasskey(const QDBusObjectPath& device, quint32 passkey, quint16 entered);
 	void Cancel();
 	void Release();
+	// NOLINTEND
+
+signals:
+	void pairingRequested(
+	    const QString& deviceAddress,
+	    BluetoothPairingRequestType::Enum type,
+	    quint32 passkey,
+	    quint32 token
+	);
+	void agentReleased();
 
 private:
+	struct PendingRequest {
+		QDBusMessage message;
+		BluetoothPairingRequestType::Enum type;
+		QString devicePath;
+		quint32 serial;
+	};
+
+	[[nodiscard]] static QString getDeviceAddress(const QDBusObjectPath& device);
+	void enqueuePendingRequest(const QDBusObjectPath& device, BluetoothPairingRequestType::Enum type);
+
 	QString mObjectPath;
+	QHash<quint32, PendingRequest> mPendingRequests;
+	quint32 mLastSerial = 0;
 };
 
 } // namespace qs::bluetooth

--- a/src/bluetooth/bluez.hpp
+++ b/src/bluetooth/bluez.hpp
@@ -15,6 +15,7 @@
 namespace qs::bluetooth {
 
 class BluetoothAdapter;
+class BluetoothAgent;
 class BluetoothDevice;
 
 class Bluez: public QObject {
@@ -42,8 +43,10 @@ private slots:
 private:
 	explicit Bluez();
 	void init();
+	void registerAgent();
 
 	qs::dbus::DBusObjectManager* objectManager = nullptr;
+	BluetoothAgent* agent = nullptr;
 	QHash<QString, BluetoothAdapter*> mAdapterMap;
 	QHash<QString, BluetoothDevice*> mDeviceMap;
 	ObjectModel<BluetoothAdapter> mAdapters {this};

--- a/src/bluetooth/bluez.hpp
+++ b/src/bluetooth/bluez.hpp
@@ -42,9 +42,16 @@ private slots:
 
 private:
 	explicit Bluez();
+	~Bluez();
 	void init();
 	void registerAgent();
+	void unregisterAgent();
+	void setupBlueZWatcher();
 
+public:
+	[[nodiscard]] BluetoothAgent* getAgent() const { return this->agent; }
+
+private:
 	qs::dbus::DBusObjectManager* objectManager = nullptr;
 	BluetoothAgent* agent = nullptr;
 	QHash<QString, BluetoothAdapter*> mAdapterMap;
@@ -77,6 +84,8 @@ class BluezQml: public QObject {
 	/// A list of all connected bluetooth devices across all adapters.
 	/// See @@BluetoothAdapter.devices for the devices connected to a single adapter.
 	Q_PROPERTY(UntypedObjectModel* devices READ devices CONSTANT);
+	/// The bluetooth agent for handling pairing requests.
+	Q_PROPERTY(BluetoothAgent* agent READ agent CONSTANT);
 	// clang-format on
 
 signals:
@@ -95,6 +104,11 @@ public:
 
 	[[nodiscard]] static QBindable<BluetoothAdapter*> bindableDefaultAdapter() {
 		return &Bluez::instance()->bDefaultAdapter;
+	}
+
+	[[nodiscard]] static BluetoothAgent* agent() {
+		auto* instance = Bluez::instance();
+		return instance ? instance->getAgent() : nullptr;
 	}
 };
 

--- a/src/bluetooth/device.cpp
+++ b/src/bluetooth/device.cpp
@@ -118,7 +118,7 @@ void BluetoothDevice::connect() {
 			    this->bState = this->bConnected ? BluetoothDeviceState::Connected
 			                                    : BluetoothDeviceState::Disconnected;
 		    } else {
-			    qCDebug(logDevice) << "Successfully connected to device" << this;
+			    qCDebug(logDevice) << "Successfully connected to to device" << this;
 		    }
 
 		    delete watcher;
@@ -293,8 +293,6 @@ void BluetoothDevice::onConnectedChanged() {
 	    this->bConnected ? BluetoothDeviceState::Connected : BluetoothDeviceState::Disconnected;
 	emit this->connectedChanged();
 }
-
-void BluetoothDevice::onServicesResolvedChanged() { emit this->servicesResolvedChanged(); }
 
 } // namespace qs::bluetooth
 

--- a/src/bluetooth/device.cpp
+++ b/src/bluetooth/device.cpp
@@ -46,6 +46,7 @@ BluetoothDevice::BluetoothDevice(const QString& path, QObject* parent): QObject(
 	}
 
 	this->properties.setInterface(this->mInterface);
+	this->properties.updateAllViaGetAll();
 }
 
 BluetoothAdapter* BluetoothDevice::adapter() const {
@@ -117,7 +118,7 @@ void BluetoothDevice::connect() {
 			    this->bState = this->bConnected ? BluetoothDeviceState::Connected
 			                                    : BluetoothDeviceState::Disconnected;
 		    } else {
-			    qCDebug(logDevice) << "Successfully connected to to device" << this;
+			    qCDebug(logDevice) << "Successfully connected to device" << this;
 		    }
 
 		    delete watcher;
@@ -292,6 +293,8 @@ void BluetoothDevice::onConnectedChanged() {
 	    this->bConnected ? BluetoothDeviceState::Connected : BluetoothDeviceState::Disconnected;
 	emit this->connectedChanged();
 }
+
+void BluetoothDevice::onServicesResolvedChanged() { emit this->servicesResolvedChanged(); }
 
 } // namespace qs::bluetooth
 

--- a/src/bluetooth/device.hpp
+++ b/src/bluetooth/device.hpp
@@ -95,6 +95,8 @@ class BluetoothDevice: public QObject {
 	Q_PROPERTY(bool blocked READ blocked WRITE setBlocked NOTIFY blockedChanged);
 	/// True if the device is allowed to wake up the host system from suspend.
 	Q_PROPERTY(bool wakeAllowed READ wakeAllowed WRITE setWakeAllowed NOTIFY wakeAllowedChanged);
+	/// True if device services (GATT/SDP) have been resolved and device is fully ready.
+	Q_PROPERTY(bool servicesResolved READ servicesResolved NOTIFY servicesResolvedChanged);
 	/// True if the connected device reports its battery level. Battery level can be accessed via @@battery.
 	Q_PROPERTY(bool batteryAvailable READ batteryAvailable NOTIFY batteryAvailableChanged);
 	/// Battery level of the connected device, from `0.0` to `1.0`. Only valid if @@batteryAvailable is true.
@@ -145,6 +147,8 @@ public:
 	[[nodiscard]] bool wakeAllowed() const { return this->bWakeAllowed; }
 	void setWakeAllowed(bool wakeAllowed);
 
+	[[nodiscard]] bool servicesResolved() const { return this->bServicesResolved; }
+
 	[[nodiscard]] bool pairing() const { return this->bPairing; }
 
 	[[nodiscard]] QBindable<QString> bindableAddress() { return &this->bAddress; }
@@ -156,6 +160,7 @@ public:
 	[[nodiscard]] QBindable<bool> bindableTrusted() { return &this->bTrusted; }
 	[[nodiscard]] QBindable<bool> bindableBlocked() { return &this->bBlocked; }
 	[[nodiscard]] QBindable<bool> bindableWakeAllowed() { return &this->bWakeAllowed; }
+	[[nodiscard]] QBindable<bool> bindableServicesResolved() { return &this->bServicesResolved; }
 	[[nodiscard]] QBindable<QString> bindableIcon() { return &this->bIcon; }
 	[[nodiscard]] QBindable<qreal> bindableBattery() { return &this->bBattery; }
 	[[nodiscard]] QBindable<BluetoothDeviceState::Enum> bindableState() { return &this->bState; }
@@ -175,6 +180,7 @@ signals:
 	void trustedChanged();
 	void blockedChanged();
 	void wakeAllowedChanged();
+	void servicesResolvedChanged();
 	void iconChanged();
 	void batteryAvailableChanged();
 	void batteryChanged();
@@ -182,6 +188,7 @@ signals:
 
 private:
 	void onConnectedChanged();
+	void onServicesResolvedChanged();
 
 	DBusBluezDeviceInterface* mInterface = nullptr;
 	QDBusInterface* mBatteryInterface = nullptr;
@@ -196,6 +203,7 @@ private:
 	Q_OBJECT_BINDABLE_PROPERTY(BluetoothDevice, bool, bTrusted, &BluetoothDevice::trustedChanged);
 	Q_OBJECT_BINDABLE_PROPERTY(BluetoothDevice, bool, bBlocked, &BluetoothDevice::blockedChanged);
 	Q_OBJECT_BINDABLE_PROPERTY(BluetoothDevice, bool, bWakeAllowed, &BluetoothDevice::wakeAllowedChanged);
+	Q_OBJECT_BINDABLE_PROPERTY(BluetoothDevice, bool, bServicesResolved, &BluetoothDevice::onServicesResolvedChanged);
 	Q_OBJECT_BINDABLE_PROPERTY(BluetoothDevice, QString, bIcon, &BluetoothDevice::iconChanged);
 	Q_OBJECT_BINDABLE_PROPERTY(BluetoothDevice, QDBusObjectPath, bAdapterPath);
 	Q_OBJECT_BINDABLE_PROPERTY(BluetoothDevice, qreal, bBattery, &BluetoothDevice::batteryChanged);
@@ -212,6 +220,7 @@ private:
 	QS_DBUS_PROPERTY_BINDING(BluetoothDevice, pTrusted, bTrusted, properties, "Trusted");
 	QS_DBUS_PROPERTY_BINDING(BluetoothDevice, pBlocked, bBlocked, properties, "Blocked");
 	QS_DBUS_PROPERTY_BINDING(BluetoothDevice, pWakeAllowed, bWakeAllowed, properties, "WakeAllowed");
+	QS_DBUS_PROPERTY_BINDING(BluetoothDevice, pServicesResolved, bServicesResolved, properties, "ServicesResolved");
 	QS_DBUS_PROPERTY_BINDING(BluetoothDevice, pIcon, bIcon, properties, "Icon");
 	QS_DBUS_PROPERTY_BINDING(BluetoothDevice, pAdapterPath, bAdapterPath, properties, "Adapter");
 

--- a/src/bluetooth/device.hpp
+++ b/src/bluetooth/device.hpp
@@ -95,8 +95,6 @@ class BluetoothDevice: public QObject {
 	Q_PROPERTY(bool blocked READ blocked WRITE setBlocked NOTIFY blockedChanged);
 	/// True if the device is allowed to wake up the host system from suspend.
 	Q_PROPERTY(bool wakeAllowed READ wakeAllowed WRITE setWakeAllowed NOTIFY wakeAllowedChanged);
-	/// True if device services (GATT/SDP) have been resolved and device is fully ready.
-	Q_PROPERTY(bool servicesResolved READ servicesResolved NOTIFY servicesResolvedChanged);
 	/// True if the connected device reports its battery level. Battery level can be accessed via @@battery.
 	Q_PROPERTY(bool batteryAvailable READ batteryAvailable NOTIFY batteryAvailableChanged);
 	/// Battery level of the connected device, from `0.0` to `1.0`. Only valid if @@batteryAvailable is true.
@@ -147,8 +145,6 @@ public:
 	[[nodiscard]] bool wakeAllowed() const { return this->bWakeAllowed; }
 	void setWakeAllowed(bool wakeAllowed);
 
-	[[nodiscard]] bool servicesResolved() const { return this->bServicesResolved; }
-
 	[[nodiscard]] bool pairing() const { return this->bPairing; }
 
 	[[nodiscard]] QBindable<QString> bindableAddress() { return &this->bAddress; }
@@ -160,7 +156,6 @@ public:
 	[[nodiscard]] QBindable<bool> bindableTrusted() { return &this->bTrusted; }
 	[[nodiscard]] QBindable<bool> bindableBlocked() { return &this->bBlocked; }
 	[[nodiscard]] QBindable<bool> bindableWakeAllowed() { return &this->bWakeAllowed; }
-	[[nodiscard]] QBindable<bool> bindableServicesResolved() { return &this->bServicesResolved; }
 	[[nodiscard]] QBindable<QString> bindableIcon() { return &this->bIcon; }
 	[[nodiscard]] QBindable<qreal> bindableBattery() { return &this->bBattery; }
 	[[nodiscard]] QBindable<BluetoothDeviceState::Enum> bindableState() { return &this->bState; }
@@ -180,7 +175,6 @@ signals:
 	void trustedChanged();
 	void blockedChanged();
 	void wakeAllowedChanged();
-	void servicesResolvedChanged();
 	void iconChanged();
 	void batteryAvailableChanged();
 	void batteryChanged();
@@ -188,7 +182,6 @@ signals:
 
 private:
 	void onConnectedChanged();
-	void onServicesResolvedChanged();
 
 	DBusBluezDeviceInterface* mInterface = nullptr;
 	QDBusInterface* mBatteryInterface = nullptr;
@@ -203,7 +196,6 @@ private:
 	Q_OBJECT_BINDABLE_PROPERTY(BluetoothDevice, bool, bTrusted, &BluetoothDevice::trustedChanged);
 	Q_OBJECT_BINDABLE_PROPERTY(BluetoothDevice, bool, bBlocked, &BluetoothDevice::blockedChanged);
 	Q_OBJECT_BINDABLE_PROPERTY(BluetoothDevice, bool, bWakeAllowed, &BluetoothDevice::wakeAllowedChanged);
-	Q_OBJECT_BINDABLE_PROPERTY(BluetoothDevice, bool, bServicesResolved, &BluetoothDevice::onServicesResolvedChanged);
 	Q_OBJECT_BINDABLE_PROPERTY(BluetoothDevice, QString, bIcon, &BluetoothDevice::iconChanged);
 	Q_OBJECT_BINDABLE_PROPERTY(BluetoothDevice, QDBusObjectPath, bAdapterPath);
 	Q_OBJECT_BINDABLE_PROPERTY(BluetoothDevice, qreal, bBattery, &BluetoothDevice::batteryChanged);
@@ -220,7 +212,6 @@ private:
 	QS_DBUS_PROPERTY_BINDING(BluetoothDevice, pTrusted, bTrusted, properties, "Trusted");
 	QS_DBUS_PROPERTY_BINDING(BluetoothDevice, pBlocked, bBlocked, properties, "Blocked");
 	QS_DBUS_PROPERTY_BINDING(BluetoothDevice, pWakeAllowed, bWakeAllowed, properties, "WakeAllowed");
-	QS_DBUS_PROPERTY_BINDING(BluetoothDevice, pServicesResolved, bServicesResolved, properties, "ServicesResolved");
 	QS_DBUS_PROPERTY_BINDING(BluetoothDevice, pIcon, bIcon, properties, "Icon");
 	QS_DBUS_PROPERTY_BINDING(BluetoothDevice, pAdapterPath, bAdapterPath, properties, "Adapter");
 

--- a/src/bluetooth/org.bluez.Agent.xml
+++ b/src/bluetooth/org.bluez.Agent.xml
@@ -1,0 +1,15 @@
+<node>
+  <interface name="org.bluez.Agent1">
+    <method name="RequestAuthorization">
+      <arg name="device" type="o" direction="in"/>
+    </method>
+    <method name="RequestConfirmation">
+      <arg name="device" type="o" direction="in"/>
+      <arg name="passkey" type="u" direction="in"/>
+    </method>
+    <method name="Cancel">
+    </method>
+    <method name="Release">
+    </method>
+  </interface>
+</node>

--- a/src/bluetooth/org.bluez.Agent.xml
+++ b/src/bluetooth/org.bluez.Agent.xml
@@ -7,6 +7,25 @@
       <arg name="device" type="o" direction="in"/>
       <arg name="passkey" type="u" direction="in"/>
     </method>
+    <method name="AuthorizeService">
+      <arg name="device" type="o" direction="in"/>
+      <arg name="uuid" type="s" direction="in"/>
+    </method>
+    <method name="RequestPinCode">
+      <arg name="device" type="o" direction="in"/>
+    </method>
+    <method name="RequestPasskey">
+      <arg name="device" type="o" direction="in"/>
+    </method>
+    <method name="DisplayPinCode">
+      <arg name="device" type="o" direction="in"/>
+      <arg name="pincode" type="s" direction="in"/>
+    </method>
+    <method name="DisplayPasskey">
+      <arg name="device" type="o" direction="in"/>
+      <arg name="passkey" type="u" direction="in"/>
+      <arg name="entered" type="q" direction="in"/>
+    </method>
     <method name="Cancel">
     </method>
     <method name="Release">

--- a/src/bluetooth/org.bluez.AgentManager.xml
+++ b/src/bluetooth/org.bluez.AgentManager.xml
@@ -1,0 +1,14 @@
+<node>
+  <interface name="org.bluez.AgentManager1">
+    <method name="RegisterAgent">
+      <arg name="agent" type="o" direction="in"/>
+      <arg name="capability" type="s" direction="in"/>
+    </method>
+    <method name="UnregisterAgent">
+      <arg name="agent" type="o" direction="in"/>
+    </method>
+    <method name="RequestDefaultAgent">
+      <arg name="agent" type="o" direction="in"/>
+    </method>
+  </interface>
+</node>


### PR DESCRIPTION
Implements a bluetooth pairing agent that is required to pair a variety of devices.

Currently, you're unable to pair any device that requires a pin, confirmation dialog, passkey, etc. Hopefully this can bring quickshell closer to being a replacement for blueman, bluetoothctl commands, etc.

It sends a signal when a device needs confirmation, pin, etc. IE:

```js
Connections {
    target: Bluetooth.agent

    function onPairingRequested(deviceAddress, type, passkey, token) {
        switch (type) {
        case BluetoothPairingRequestType.Authorization:
            // Show "Allow pairing?" dialog
            Bluetooth.agent.respondToRequest(token, true) // Accept
            break

        case BluetoothPairingRequestType.Confirmation:
            // Show "Confirm passkey: ${passkey}?" dialog
            Bluetooth.agent.respondToRequest(token, true) // Accept
            break

        case BluetoothPairingRequestType.PinCode:
            // Show PIN entry dialog
            Bluetooth.agent.respondWithPinCode(token, "1234")
            break

        case BluetoothPairingRequestType.Passkey:
            // Show numeric entry dialog
            Bluetooth.agent.respondWithPasskey(token, 123456)
            break
        }
    }
}
```