### PR TITLE
hyprland/workspace: Use name instead of id for activate

### DIFF
--- a/src/wayland/hyprland/ipc/workspace.cpp
+++ b/src/wayland/hyprland/ipc/workspace.cpp
@@ -151,7 +151,7 @@ void HyprlandWorkspace::clearUrgent() {
 }
 
 void HyprlandWorkspace::activate() {
-	this->ipc->dispatch(QString("workspace %1").arg(this->bId.value()));
+	this->ipc->dispatch(QString("workspace %1").arg(this->bName.value()));
 }
 
 } // namespace qs::hyprland::ipc

--- a/src/wayland/hyprland/ipc/workspace.hpp
+++ b/src/wayland/hyprland/ipc/workspace.hpp
@@ -54,7 +54,7 @@ public:
 	///
 	/// > [!NOTE] This is equivalent to running
 	/// > ```qml
-	/// > HyprlandIpc.dispatch(`workspace ${workspace.id}`);
+	/// > HyprlandIpc.dispatch(`workspace ${workspace.name}`);
 	/// > ```
 	Q_INVOKABLE void activate();
 


### PR DESCRIPTION
When using named workspaces Hyprland gives them a negative id so when we run `workspace ${workspace.id}` hyprland treats this as a relative id. So if you are on workspace 3 then go to workspace Web Quickshell will run `workspace -1337` but Hyprland will rightfully complain that workspace -1334 does not exist. Running `workspace ${workspace.name}` seems to mitigate this issue.

See https://wiki.hypr.land/Configuring/Dispatchers/#workspaces
> - ID: e.g. `1`, `2`, or `3`
> - Relative ID: e.g. `+1`, `-3` or `+100`
> - workspace on monitor, relative with `+` or `-`, absolute with `~`: e.g. `m+1`, `m-2` or `m~3`
> - workspace on monitor including empty workspaces, relative with `+` or `-`, absolute with `~`: e.g. `r+1` or `r~3`
> - open workspace, relative with `+` or `-`, absolute with `~`: e.g. `e+1`, `e-10`, or `e~2`
> - Name: e.g. `name:Web`, `name:Anime` or `name:Better anime`
> - Previous workspace: `previous`, or `previous_per_monitor`
> - First available empty workspace: `empty`, suffix with `m` to only search on monitor. and/or n to make it the next available empty workspace. e.g. `emptynm`
> - Special Workspace: `special` or `special:name` for named special workspaces.