### PR TITLE
build: add systemd service

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,3 +157,9 @@ install(
 	DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/scalable/apps
 	RENAME org.quickshell.svg
 )
+
+configure_file(assets/quickshell.service.in quickshell.service)
+install(
+	FILES ${CMAKE_BINARY_DIR}/quickshell.service
+	DESTINATION lib/systemd/user
+)

--- a/assets/quickshell.service.in
+++ b/assets/quickshell.service.in
@@ -1,0 +1,10 @@
+[Unit]
+Description=QtQuick-based Desktop Shell Toolkit
+PartOf=graphical-session.target
+Requisite=graphical-session.target
+After=graphical-session.target
+
+[Service]
+ExecStart=@CMAKE_INSTALL_BINDIR@/quickshell
+Slice=session.slice
+Restart=on-failure

--- a/default.nix
+++ b/default.nix
@@ -116,10 +116,12 @@
     dontUnpack = true;
     dontConfigure = true;
     dontBuild = true;
+    dontMoveSystemdUserUnits = true;
 
     installPhase = ''
-      mkdir -p $out
-      cp -r ${unwrapped}/* $out
+      cp -r ${unwrapped} $out
+      substituteInPlace $out/lib/systemd/user/quickshell.service \
+        --replace-fail ${unwrapped} $out
     '';
 
     passthru = {


### PR DESCRIPTION
Adds a systemd unit configuration file to be installed by CMake.

My motivation is being able to auto-start Quickshell on NixOS/niri with just the following module options:
```nix
systemd.packages = with pkgs; [ quickshell ];
systemd.user.services.quickshell.wantedBy = [ "niri.service" ];
```
A caveat is that the service `PATH` will be limited, meaning `DesktopEntry.execute()` will often not work directly.

C.f.: https://github.com/Alexays/Waybar/blob/0776e694df56c2c849b682369148210d81324e93/resources/waybar.service.in

Tangentially, it would be neat if an `Exec=` key got added to `org.quickshell.desktop`, so it could be placed in `/etc/xdg/autostart`.