### PR TITLE
core/log: Fix nullptr crash in ThreadLogging

### DIFF
--- a/src/core/logging.cpp
+++ b/src/core/logging.cpp
@@ -458,13 +458,13 @@ void ThreadLogging::onMessage(const LogMessage& msg, bool showInSparse) {
 	}
 
 	if (!this->detailedWriter.write(msg) || (this->detailedFile && !this->detailedFile->flush())) {
+		this->detailedWriter.setDevice(nullptr);
+
 		if (this->detailedFile) {
+			this->detailedFile->close();
+			this->detailedFile = nullptr;
 			qCCritical(logLogging) << "Detailed logger failed to write. Ending detailed logs.";
 		}
-
-		this->detailedWriter.setDevice(nullptr);
-		this->detailedFile->close();
-		this->detailedFile = nullptr;
 	}
 }
 


### PR DESCRIPTION
At some point, quickshell on my system crashed and wouldn't start again. After building a debug version, I noticed the crash was due to a nullptr deref, fixed in this PR.

```
[New Thread 0x7fffef7ff6c0 (LWP 295335)]
  INFO: Launching config: "/nix/store/wlq543267h79qwdig63cg43kykkib45f-hv2iqc4592h80mdb8b90prr3qzcwcdi1-source/shell.qml"
  INFO: Shell ID: "bc1465e6ad38688c799dcd58bf3be599" Path ID "bc1465e6ad38688c799dcd58bf3be599"
  INFO: Saving logs to "/run/user/1000/quickshell/by-id/ovb60byx0t/log.qslog"
Detailed logger failed to write. Ending detailed logs.

Thread 2 "QThread" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7fffef7ff6c0 (LWP 295335)]
0x00005555556c6cec in qs::log::ThreadLogging::onMessage (this=0x7fffeea19140, msg=..., showInSparse=<optimized out>) at /home/derock/Documents/Code/quickshell/src/core/logging.cpp:466
466     this->detailedFile->close();
(gdb) bt
#0  0x00005555556c6cec in qs::log::ThreadLogging::onMessage (this=0x7fffeea19140, msg=..., showInSparse=<optimized out>) at /home/derock/Documents/Code/quickshell/src/core/logging.cpp:466
#1  0x00007ffff4c0dd97 in QObject::event(QEvent*) () from /nix/store/8qs879yx84gng0yljdybwi4fbbgg3dyy-qtbase-6.9.0/lib/libQt6Core.so.6
#2  0x00007ffff4bb262d in QCoreApplication::notifyInternal2(QObject*, QEvent*) () from /nix/store/8qs879yx84gng0yljdybwi4fbbgg3dyy-qtbase-6.9.0/lib/libQt6Core.so.6
#3  0x00007ffff4bb63e4 in QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*) () from /nix/store/8qs879yx84gng0yljdybwi4fbbgg3dyy-qtbase-6.9.0/lib/libQt6Core.so.6
#4  0x00007ffff4ec42c7 in postEventSourceDispatch(_GSource*, int (*)(void*), void*) () from /nix/store/8qs879yx84gng0yljdybwi4fbbgg3dyy-qtbase-6.9.0/lib/libQt6Core.so.6
#5  0x00007ffff450181e in g_main_context_dispatch_unlocked () from /nix/store/bkpj51fz88rbyjd60i6lrp0xdax1b24g-glib-2.84.1/lib/libglib-2.0.so.0
#6  0x00007ffff4503a90 in g_main_context_iterate_unlocked.isra () from /nix/store/bkpj51fz88rbyjd60i6lrp0xdax1b24g-glib-2.84.1/lib/libglib-2.0.so.0
#7  0x00007ffff45042bc in g_main_context_iteration () from /nix/store/bkpj51fz88rbyjd60i6lrp0xdax1b24g-glib-2.84.1/lib/libglib-2.0.so.0
#8  0x00007ffff4ec39a3 in QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) () from /nix/store/8qs879yx84gng0yljdybwi4fbbgg3dyy-qtbase-6.9.0/lib/libQt6Core.so.6
#9  0x00007ffff4bc0beb in QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) () from /nix/store/8qs879yx84gng0yljdybwi4fbbgg3dyy-qtbase-6.9.0/lib/libQt6Core.so.6
#10 0x00007ffff4ce0710 in QThread::exec() () from /nix/store/8qs879yx84gng0yljdybwi4fbbgg3dyy-qtbase-6.9.0/lib/libQt6Core.so.6
#11 0x00007ffff4d823b2 in QThreadPrivate::start(void*) () from /nix/store/8qs879yx84gng0yljdybwi4fbbgg3dyy-qtbase-6.9.0/lib/libQt6Core.so.6
#12 0x00007ffff4297e63 in start_thread () from /nix/store/cg9s562sa33k78m63njfn1rw47dp9z0i-glibc-2.40-66/lib/libc.so.6
#13 0x00007ffff431bdbc in __clone3 () from /nix/store/cg9s562sa33k78m63njfn1rw47dp9z0i-glibc-2.40-66/lib/libc.so.6
(gdb) p this->detailedFile
$1 = (QFile *) 0x0
```