### PR TITLE
wayland/idle-inhibit: fix compilation on QT < 6.9

### DIFF
--- a/src/wayland/idle_inhibit/inhibitor.cpp
+++ b/src/wayland/idle_inhibit/inhibitor.cpp
@@ -13,7 +13,7 @@ namespace qs::wayland::idle_inhibit {
 using QtWaylandClient::QWaylandWindow;
 
 IdleInhibitor::IdleInhibitor() {
-	this->bBoundWindow.setBinding([this] { return this->bEnabled ? this->bWindowObject : nullptr; });
+	this->bBoundWindow.setBinding([this] { return this->bEnabled ? this->bWindowObject.value() : nullptr; });
 }
 
 QObject* IdleInhibitor::window() const { return this->bWindowObject; }


### PR DESCRIPTION
I presume, in QT 6.9 it implicitly casts `QObjectBindableProperty` as `QObject` - but with QT < 6.9 (maybe other older parts of the toolchain) it doesn't compile. So just added `.value()` to explicitly grab the QObject which fixes the compilation