### PR TITLE
service/greetd: always send responses

### DIFF
--- a/src/services/greetd/connection.cpp
+++ b/src/services/greetd/connection.cpp
@@ -225,6 +225,11 @@ void GreetdConnection::onSocketReady() {
 
 		this->mResponseRequired = responseRequired;
 		emit this->authMessage(message, error, responseRequired, echoResponse);
+
+		if (!responseRequired)
+			this->sendRequest({
+			        {"type", "post_auth_message_response"}
+			});
 	} else goto unexpected;
 
 	return;


### PR DESCRIPTION
I use the greetd service with a pam configuration that allows logging in with fprintd.

Since on master the greetd session blocks after the pam fprintd messages a prompt to touch the scanner and greetd relays it to quickshell, it appears to me that greetd expects every message to be acknowledged even if no text response is required.