### PR TITLE
services/tray: Signal tooltip changes to qml

### DIFF
--- a/changelog/next.md
+++ b/changelog/next.md
@@ -28,6 +28,7 @@ set shell id.
 - Fixed volumes not initializing if a pipewire device was already loaded before its node.
 - Fixed hyprland active toplevel not resetting after window closes.
 - Fixed hyprland ipc window names and titles being reversed.
+- Fixed missing signals for system tray item title and description updates.
 
 ## Packaging Changes
 

--- a/src/services/status_notifier/item.hpp
+++ b/src/services/status_notifier/item.hpp
@@ -207,6 +207,8 @@ private:
 	QS_BINDING_SUBSCRIBE_METHOD(StatusNotifierItem, bOverlayIconPixmaps, updatePixmapIndex, onValueChanged);
 	QS_BINDING_SUBSCRIBE_METHOD(StatusNotifierItem, bAttentionIconPixmaps, updatePixmapIndex, onValueChanged);
 	QS_BINDING_SUBSCRIBE_METHOD(StatusNotifierItem, bMenuPath, onMenuPathChanged, onValueChanged);
+	QS_BINDING_SUBSCRIBE_METHOD(StatusNotifierItem, bTooltip, tooltipTitleChanged, onValueChanged);
+	QS_BINDING_SUBSCRIBE_METHOD(StatusNotifierItem, bTooltip, tooltipDescriptionChanged, onValueChanged);
 	Q_OBJECT_BINDABLE_PROPERTY(StatusNotifierItem, quint32, pixmapIndex);
 	Q_OBJECT_BINDABLE_PROPERTY(StatusNotifierItem, QString, bIcon, &StatusNotifierItem::iconChanged);
 


### PR DESCRIPTION
Previously, the tooltipTitleChanged and tooltipDescriptionChanged were never emitted.