### PR TITLE
core/window: add startSystemMove, startSystemResize, maximize, and fullscreen

### DIFF
--- a/changelog/next.md
+++ b/changelog/next.md
@@ -16,6 +16,8 @@ set shell id.
 - Added support for wayland idle timeouts.
 - Added support for inhibiting wayland compositor shortcuts for focused windows.
 - Added the ability to override Quickshell.cacheDir with a custom path.
+- Added minimized, maximized, and fullscreen properties to FloatingWindow.
+- Added the ability to handle move and resize events to FloatingWindow.
 
 ## Other Changes
 

--- a/src/window/floatingwindow.hpp
+++ b/src/window/floatingwindow.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <qnamespace.h>
 #include <qobject.h>
 #include <qproperty.h>
 #include <qsize.h>
@@ -68,6 +69,12 @@ class FloatingWindowInterface: public WindowInterface {
 	Q_PROPERTY(QSize minimumSize READ default WRITE default NOTIFY minimumSizeChanged BINDABLE bindableMinimumSize);
 	/// Maximum window size given to the window system.
 	Q_PROPERTY(QSize maximumSize READ default WRITE default NOTIFY maximumSizeChanged BINDABLE bindableMaximumSize);
+	/// Whether the window is currently minimized.
+	Q_PROPERTY(bool minimized READ isMinimized WRITE setMinimized NOTIFY minimizedChanged);
+	/// Whether the window is currently maximized.
+	Q_PROPERTY(bool maximized READ isMaximized WRITE setMaximized NOTIFY maximizedChanged);
+	/// Whether the window is currently fullscreen.
+	Q_PROPERTY(bool fullscreen READ isFullscreen WRITE setFullscreen NOTIFY fullscreenChanged);
 	// clang-format on
 	QML_NAMED_ELEMENT(FloatingWindow);
 
@@ -78,15 +85,40 @@ public:
 
 	[[nodiscard]] ProxyWindowBase* proxyWindow() const override;
 
-	QBindable<QSize> bindableMinimumSize() { return &this->window->bMinimumSize; }
-	QBindable<QSize> bindableMaximumSize() { return &this->window->bMaximumSize; }
-	QBindable<QString> bindableTitle() { return &this->window->bTitle; }
+	[[nodiscard]] QBindable<QSize> bindableMinimumSize() { return &this->window->bMinimumSize; }
+	[[nodiscard]] QBindable<QSize> bindableMaximumSize() { return &this->window->bMaximumSize; }
+	[[nodiscard]] QBindable<QString> bindableTitle() { return &this->window->bTitle; }
+
+	[[nodiscard]] bool isMinimized() const;
+	void setMinimized(bool minimized);
+	[[nodiscard]] bool isMaximized() const;
+	void setMaximized(bool maximized);
+	[[nodiscard]] bool isFullscreen() const;
+	void setFullscreen(bool fullscreen);
+
+	/// Start a system move operation. Must be called during a pointer press/drag.
+	Q_INVOKABLE [[nodiscard]] bool startSystemMove() const;
+	/// Start a system resize operation. Must be called during a pointer press/drag.
+	Q_INVOKABLE [[nodiscard]] bool startSystemResize(Qt::Edges edges) const;
 
 signals:
 	void minimumSizeChanged();
 	void maximumSizeChanged();
 	void titleChanged();
+	void minimizedChanged();
+	void maximizedChanged();
+	void fullscreenChanged();
+
+private slots:
+	void onWindowConnected();
+	void onWindowStateChanged();
 
 private:
 	ProxyFloatingWindow* window;
+	bool mMinimized = false;
+	bool mMaximized = false;
+	bool mFullscreen = false;
+	bool mWasMinimized = false;
+	bool mWasMaximized = false;
+	bool mWasFullscreen = false;
 };


### PR DESCRIPTION
Allows to trigger move and resize operations on QsWindow, useful for making a built-in CSD, etc.

Also expose maximize and fullscreen methods and bindables.