### PR TITLE
core/window: add parentWindow property to FloatingWindow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project(quickshell VERSION "0.2.1" LANGUAGES CXX C)
 set(UNRELEASED_FEATURES
 	"network.2"
 	"colorquant-imagerect"
+	"window-parent"
 )
 
 set(QT_MIN_VERSION "6.6.0")

--- a/changelog/next.md
+++ b/changelog/next.md
@@ -30,6 +30,7 @@ set shell id.
 - Added ext-background-effect window blur support.
 - Added per-corner radius support to Region.
 - Added ColorQuantizer region selection.
+- Added dialog window support to FloatingWindow.
 
 ## Other Changes
 

--- a/src/window/floatingwindow.cpp
+++ b/src/window/floatingwindow.cpp
@@ -3,13 +3,34 @@
 #include <qnamespace.h>
 #include <qobject.h>
 #include <qqmlengine.h>
-#include <qqmllist.h>
+#include <qqmlinfo.h>
 #include <qtmetamacros.h>
 #include <qtypes.h>
 #include <qwindow.h>
 
 #include "proxywindow.hpp"
 #include "windowinterface.hpp"
+
+ProxyFloatingWindow::ProxyFloatingWindow(QObject* parent): ProxyWindowBase(parent) {
+	this->bTargetVisible.setBinding([this] {
+		if (!this->bWantsVisible) return false;
+		auto* parent = this->bParentProxyWindow.value();
+		if (!parent) return true;
+		return parent->bindableBackerVisibility().value();
+	});
+}
+
+void ProxyFloatingWindow::targetVisibleChanged() {
+	if (this->window && this->bParentProxyWindow) {
+		auto* bw = this->bParentProxyWindow.value()->backingWindow();
+
+		if (bw != this->window->transientParent()) {
+			this->window->setTransientParent(bw);
+		}
+	}
+
+	this->ProxyWindowBase::setVisible(this->bTargetVisible);
+}
 
 void ProxyFloatingWindow::connectWindow() {
 	this->ProxyWindowBase::connectWindow();
@@ -18,6 +39,25 @@ void ProxyFloatingWindow::connectWindow() {
 	this->window->setMinimumSize(this->bMinimumSize);
 	this->window->setMaximumSize(this->bMaximumSize);
 }
+
+void ProxyFloatingWindow::completeWindow() {
+	this->ProxyWindowBase::completeWindow();
+
+	auto* parent = this->bParentProxyWindow.value();
+	this->window->setTransientParent(parent ? parent->backingWindow() : nullptr);
+}
+
+void ProxyFloatingWindow::postCompleteWindow() {
+	this->ProxyWindowBase::setVisible(this->bTargetVisible);
+}
+
+void ProxyFloatingWindow::onParentDestroyed() {
+	this->mParentWindow = nullptr;
+	this->bParentProxyWindow = nullptr;
+	emit this->parentWindowChanged();
+}
+
+void ProxyFloatingWindow::setVisible(bool visible) { this->bWantsVisible = visible; }
 
 void ProxyFloatingWindow::trySetWidth(qint32 implicitWidth) {
 	if (!this->window->isVisible()) {
@@ -46,6 +86,42 @@ void ProxyFloatingWindow::onMaximumSizeChanged() {
 	emit this->maximumSizeChanged();
 }
 
+QObject* ProxyFloatingWindow::parentWindow() const { return this->mParentWindow; }
+
+void ProxyFloatingWindow::setParentWindow(QObject* window) {
+	if (window == this->mParentWindow) return;
+
+	if (this->window && this->window->isVisible()) {
+		qmlWarning(this) << "parentWindow cannot be changed after the window is visible.";
+		return;
+	}
+
+	if (this->bParentProxyWindow) {
+		QObject::disconnect(this->bParentProxyWindow, nullptr, this, nullptr);
+	}
+
+	if (this->mParentWindow) {
+		QObject::disconnect(this->mParentWindow, nullptr, this, nullptr);
+	}
+
+	this->mParentWindow = nullptr;
+	this->bParentProxyWindow = nullptr;
+
+	if (auto* proxy = ProxyWindowBase::forObject(window)) {
+		this->mParentWindow = window;
+		this->bParentProxyWindow = proxy;
+
+		QObject::connect(
+		    this->mParentWindow,
+		    &QObject::destroyed,
+		    this,
+		    &ProxyFloatingWindow::onParentDestroyed
+		);
+	}
+
+	emit this->parentWindowChanged();
+}
+
 // FloatingWindowInterface
 
 FloatingWindowInterface::FloatingWindowInterface(QObject* parent)
@@ -57,6 +133,7 @@ FloatingWindowInterface::FloatingWindowInterface(QObject* parent)
 	QObject::connect(this->window, &ProxyFloatingWindow::titleChanged, this, &FloatingWindowInterface::titleChanged);
 	QObject::connect(this->window, &ProxyFloatingWindow::minimumSizeChanged, this, &FloatingWindowInterface::minimumSizeChanged);
 	QObject::connect(this->window, &ProxyFloatingWindow::maximumSizeChanged, this, &FloatingWindowInterface::maximumSizeChanged);
+	QObject::connect(this->window, &ProxyFloatingWindow::parentWindowChanged, this, &FloatingWindowInterface::parentWindowChanged);
 	QObject::connect(this->window, &ProxyWindowBase::windowConnected, this, &FloatingWindowInterface::onWindowConnected);
 	// clang-format on
 }
@@ -168,4 +245,10 @@ bool FloatingWindowInterface::startSystemResize(Qt::Edges edges) const {
 	auto* qw = this->window->backingWindow();
 	if (!qw) return false;
 	return qw->startSystemResize(edges);
+}
+
+QObject* FloatingWindowInterface::parentWindow() const { return this->window->parentWindow(); }
+
+void FloatingWindowInterface::setParentWindow(QObject* window) {
+	this->window->setParentWindow(window);
 }

--- a/src/window/floatingwindow.hpp
+++ b/src/window/floatingwindow.hpp
@@ -16,9 +16,15 @@ class ProxyFloatingWindow: public ProxyWindowBase {
 	Q_OBJECT;
 
 public:
-	explicit ProxyFloatingWindow(QObject* parent = nullptr): ProxyWindowBase(parent) {}
+	explicit ProxyFloatingWindow(QObject* parent = nullptr);
 
 	void connectWindow() override;
+	void completeWindow() override;
+	void postCompleteWindow() override;
+	void setVisible(bool visible) override;
+
+	[[nodiscard]] QObject* parentWindow() const;
+	void setParentWindow(QObject* window);
 
 	// Setting geometry while the window is visible makes the content item shrink but not the window
 	// which is awful so we disable it for floating windows.
@@ -29,11 +35,28 @@ signals:
 	void minimumSizeChanged();
 	void maximumSizeChanged();
 	void titleChanged();
+	void parentWindowChanged();
+
+private slots:
+	void onParentDestroyed();
 
 private:
 	void onMinimumSizeChanged();
 	void onMaximumSizeChanged();
 	void onTitleChanged();
+	void targetVisibleChanged();
+
+	QObject* mParentWindow = nullptr;
+
+	Q_OBJECT_BINDABLE_PROPERTY(ProxyFloatingWindow, ProxyWindowBase*, bParentProxyWindow);
+	Q_OBJECT_BINDABLE_PROPERTY_WITH_ARGS(ProxyFloatingWindow, bool, bWantsVisible, true);
+
+	Q_OBJECT_BINDABLE_PROPERTY(
+	    ProxyFloatingWindow,
+	    bool,
+	    bTargetVisible,
+	    &ProxyFloatingWindow::targetVisibleChanged
+	);
 
 public:
 	Q_OBJECT_BINDABLE_PROPERTY(
@@ -75,6 +98,11 @@ class FloatingWindowInterface: public WindowInterface {
 	Q_PROPERTY(bool maximized READ isMaximized WRITE setMaximized NOTIFY maximizedChanged);
 	/// Whether the window is currently fullscreen.
 	Q_PROPERTY(bool fullscreen READ isFullscreen WRITE setFullscreen NOTIFY fullscreenChanged);
+	/// The parent window of this window. Setting this makes the window a child of the parent,
+	/// which affects window stacking behavior.
+	///
+	/// > [!NOTE] This property cannot be changed after the window is visible.
+	Q_PROPERTY(QObject* parentWindow READ parentWindow WRITE setParentWindow NOTIFY parentWindowChanged);
 	// clang-format on
 	QML_NAMED_ELEMENT(FloatingWindow);
 
@@ -101,6 +129,9 @@ public:
 	/// Start a system resize operation. Must be called during a pointer press/drag.
 	Q_INVOKABLE [[nodiscard]] bool startSystemResize(Qt::Edges edges) const;
 
+	[[nodiscard]] QObject* parentWindow() const;
+	void setParentWindow(QObject* window);
+
 signals:
 	void minimumSizeChanged();
 	void maximumSizeChanged();
@@ -108,6 +139,7 @@ signals:
 	void minimizedChanged();
 	void maximizedChanged();
 	void fullscreenChanged();
+	void parentWindowChanged();
 
 private slots:
 	void onWindowConnected();

--- a/src/window/test/manual/parentwindow.qml
+++ b/src/window/test/manual/parentwindow.qml
@@ -1,0 +1,42 @@
+import QtQuick
+import QtQuick.Layouts
+import QtQuick.Controls.Fusion
+import Quickshell
+
+Scope {
+    FloatingWindow {
+        id: control
+        color: contentItem.palette.window
+        ColumnLayout {
+            CheckBox {
+                id: parentCb
+                text: "Show parent"
+            }
+
+            CheckBox {
+                id: dialogCb
+                text: "Show dialog"
+            }
+        }
+    }
+
+    FloatingWindow {
+        id: parentw
+        Text {
+            text: "parent"
+        }
+        visible: parentCb.checked
+        color: contentItem.palette.window
+
+        FloatingWindow {
+            id: dialog
+            parentWindow: parentw
+            visible: dialogCb.checked
+            color: contentItem.palette.window
+
+            Text {
+                text: "dialog"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Allows setting a parentWindow for FloatingWindow , which on wayland calls xdg_toplevel::set_parent .

Compositors may handle child windows differently (e.g. a dialog), by opening them as floating / positioned within the window that triggered them. This allows creating windows with that behavior.