### PR TITLE
hyprland/ipc: fix parsing order of windowTitle and windowClass in openwindow handler

### DIFF
--- a/src/wayland/hyprland/ipc/connection.cpp
+++ b/src/wayland/hyprland/ipc/connection.cpp
@@ -442,8 +442,8 @@ void HyprlandIpc::onEvent(HyprlandIpcEvent* event) {
 		if (!ok) return;
 
 		auto workspaceName = QString::fromUtf8(args.at(1));
-		auto windowTitle = QString::fromUtf8(args.at(2));
-		auto windowClass = QString::fromUtf8(args.at(3));
+		auto windowClass = QString::fromUtf8(args.at(2));
+		auto windowTitle = QString::fromUtf8(args.at(3));
 
 		auto* workspace = this->findWorkspaceByName(workspaceName, false);
 		if (!workspace) {


### PR DESCRIPTION
The `openwindow` event format is `WINDOWADDRESS,WORKSPACENAME,WINDOWCLASS,WINDOWTITLE`, but the handler was parsing `args.at(2)` as title and `args.at(3)` as class, which is reversed.

This caused windows to display their class name instead of their actual title when the `openwindow` event arrived after `windowtitlev2`, since `updateInitial` would overwrite the correct title with the class.

Link to official IPC format: https://wiki.hypr.land/IPC/#events-list