### PR TITLE
guix: fix package defenition

### DIFF
--- a/quickshell.scm
+++ b/quickshell.scm
@@ -70,7 +70,7 @@
                    (wrap-program (string-append #$output "/bin/quickshell")
                      `("QML_IMPORT_PATH" ":"
                        = (,(getenv "QML_IMPORT_PATH")))))))))
-    (home-page "https://quickshell.outfoxxed.me")
+    (home-page "https://quickshell.org")
     (synopsis "QtQuick-based desktop shell toolkit")
     (description
      "Quickshell is a flexible QtQuick-based toolkit for creating and

--- a/quickshell.scm
+++ b/quickshell.scm
@@ -1,5 +1,6 @@
 (define-module (quickshell)
   #:use-module ((guix licenses) #:prefix license:)
+  #:use-module (gnu packages bash)
   #:use-module (gnu packages cpp)
   #:use-module (gnu packages freedesktop)
   #:use-module (gnu packages gcc)
@@ -30,15 +31,16 @@
                         #:select? (or (git-predicate (current-source-directory))
                                       (const #t))))
     (build-system cmake-build-system)
-    (propagated-inputs (list qtbase qtdeclarative qtsvg))
+    (propagated-inputs (list qtsvg))
     (native-inputs (list ninja
                          gcc-14
                          pkg-config
                          qtshadertools
                          spirv-tools
-                         wayland-protocols
-                         cli11))
-    (inputs (list jemalloc
+                         wayland-protocols))
+    (inputs (list bash-minimal
+                  cli11
+                  jemalloc
                   libdrm
                   libxcb
                   libxkbcommon

--- a/quickshell.scm
+++ b/quickshell.scm
@@ -63,8 +63,6 @@
                    "-DCRASH_REPORTER=OFF")
            #:phases
            #~(modify-phases %standard-phases
-               (replace 'build (lambda _ (invoke "cmake" "--build" ".")))
-               (replace 'install (lambda _ (invoke "cmake" "--install" ".")))
                (add-after 'install 'wrap-program
                  (lambda* (#:key inputs #:allow-other-keys)
                    (wrap-program (string-append #$output "/bin/quickshell")

--- a/quickshell.scm
+++ b/quickshell.scm
@@ -8,6 +8,7 @@
   #:use-module (gnu packages linux)
   #:use-module (gnu packages ninja)
   #:use-module (gnu packages pkg-config)
+  #:use-module (gnu packages polkit)
   #:use-module (gnu packages qt)
   #:use-module (gnu packages vulkan)
   #:use-module (gnu packages xdisorg)


### PR DESCRIPTION
#### Changes:
1. [After last change to quickshell.scm](https://github.com/quickshell-mirror/quickshell/commit/db1777c20b936a86528c1095cbcb1ebd92801402#diff-f038d147abd680214aa0a45c9fd8478c731b2f0603accffd3cf275fab838c9fcR45) with addition of polkit, module for polkit wasn't added.

2. I found that many inputs were in wrong places, some of them even repeated. Also bash-minimal should be added since we wrap binary.
This caused errors like so when using as a channel:

```
guix home: error: profile contains conflicting entries for libxkbcommon
guix home: error:   first entry: libxkbcommon@1.11.0 /gnu/store/81knrk9sar7g1syz35dgfxlnyq1gi5l1-libxkbcommon-1.11.0
guix home: error:    ... propagated from qtbase@6.9.2
guix home: error:    ... propagated from quickshell@git
guix home: error:   second entry: libxkbcommon@1.11.0 /gnu/store/n8kmqvqjbps44jqzrib55b9vrp1rr15j-libxkbcommon-1.11.0
guix home: error:    ... propagated from gtk+@3.24.49
guix home: error:    ... propagated from network-manager-applet@1.36.0
hint: Try upgrading both `quickshell' and `network-manager-applet', or remove one of them from
```

and

```
$ QT_QPA_PLATFORM=wayland quickshell
  INFO: Launching config: "/home/ch/.config/quickshell/shell.qml"
  INFO: Shell ID: "50efbd8f00f9268d6d474eee6923db87" Path ID "50efbd8f00f9268d6d474eee6923db87"
  INFO: Saving logs to "/run/user/1000/quickshell/by-id/5vmumqi6t/log.qslog"
  WARN qt.qpa.plugin: Could not find the Qt platform plugin "wayland" in ""
 FATAL: This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.

Available platform plugins are: eglfs, linuxfb, minimal, minimalegl, offscreen, vkkhrdisplay, vnc, xcb.

fish: Job 1, 'QT_QPA_PLATFORM=wayland quicksh…' terminated by signal SIGABRT (Abort)
```

3. Currenty Guix is absolutely fine with using this repo as a channel with in-tree source, so I made [PR to docs](https://github.com/quickshell-mirror/quickshell-web/pull/16)


#### Result:
Setup:
```
$ grep -r quickshell /tmp/channels*
/tmp/channels.scm:       (name 'quickshell)
/tmp/channels.scm:       (url "https://github.com/quickshell-mirror/quickshell")
/tmp/channels2.scm:      (name 'quickshell)
/tmp/channels2.scm:      (url "https://github.com/ch4og/quickshell")

$ cat /tmp/quickshell.scm
(use-modules (quickshell)
             (gnu packages))

(packages->manifest
 (list quickshell-git))
```

Using upstream repo as a channel:

```
$ guix time-machine -C /tmp/channels.scm -- shell --container --manifest=/tmp/quickshell.scm -- quickshell --version
...
build of /gnu/store/wxsca503slgp6fw97jh4crl1791pfdpa-guix-package-cache.drv failed
hint: This usually indicates a bug in one of the channels you are pulling from, or
some incompatibility among them.  You can check the build log and report the
issue to the channel developers.

The channels you are pulling from are: guix quickshell.

View build log at '/var/log/guix/drvs/wx/sca503slgp6fw97jh4crl1791pfdpa-guix-package-cache.drv.gz'.
cannot build derivation `/gnu/store/8560ic1v4yh99565vw3wzmv90pkb0wmw-profile.drv': 1 dependencies couldn't be built
guix time-machine: error: build of `/gnu/store/8560ic1v4yh99565vw3wzmv90pkb0wmw-profile.drv' failed

$ zcat /var/log/guix/drvs/wx/sca503slgp6fw97jh4crl1791pfdpa-guix-package-cache.drv.gz
...
(exception unbound-variable (value #f) (value "Unbound variable: ~S") (value (polkit)) (value #f))
```

Using my PR's repo as a channel:

```
$ guix time-machine -C /tmp/channels2.scm -- shell --container --manifest=/tmp/quickshell.scm -- quickshell --version
...
quickshell 0.2.1, revision , distributed by: "In-tree Guix channel"
```

