### PR TITLE
Fix threading support to polkit CMake configuration

### DIFF
--- a/cmake/pch.cmake
+++ b/cmake/pch.cmake
@@ -53,13 +53,20 @@ set(COMMON_PCH_SET
 	<qabstractitemmodel.h>
 )
 
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
 qs_add_pchset(common
-	DEPENDENCIES Qt::Quick
+	DEPENDENCIES 
+		Qt::Quick
+		Threads::Threads
 	HEADERS ${COMMON_PCH_SET}
 )
 
 qs_add_pchset(large
-	DEPENDENCIES Qt::Quick
+	DEPENDENCIES 
+		Qt::Quick
+		Threads::Threads
 	HEADERS
 		${COMMON_PCH_SET}
 		<qiodevice.h>
@@ -77,7 +84,9 @@ qs_add_pchset(large
 
 # including qplugin.h directly will cause required symbols to disappear
 qs_add_pchset(plugin
-	DEPENDENCIES Qt::Qml
+	DEPENDENCIES 
+		Qt::Qml
+		Threads::Threads
 	HEADERS
 		<qobject.h>
 		<qjsonobject.h>

--- a/cmake/pch.cmake
+++ b/cmake/pch.cmake
@@ -44,6 +44,7 @@ set(COMMON_PCH_SET
 	<chrono>
 	<memory>
 	<vector>
+	<pthread.h>
 	<qdebug.h>
 	<qobject.h>
 	<qmetatype.h>

--- a/src/services/polkit/CMakeLists.txt
+++ b/src/services/polkit/CMakeLists.txt
@@ -1,4 +1,6 @@
+set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(PkgConfig REQUIRED)
+find_package(Threads REQUIRED)
 pkg_check_modules(glib REQUIRED IMPORTED_TARGET glib-2.0>=2.36)
 pkg_check_modules(gobject REQUIRED IMPORTED_TARGET gobject-2.0)
 pkg_check_modules(polkit_agent REQUIRED IMPORTED_TARGET polkit-agent-1)
@@ -28,8 +30,9 @@ target_link_libraries(quickshell-service-polkit PRIVATE
 	PkgConfig::gobject
 	PkgConfig::polkit_agent
 	PkgConfig::polkit
+	Threads::Threads
 )
 
 qs_module_pch(quickshell-service-polkit)
 
-target_link_libraries(quickshell PRIVATE quickshell-service-polkitplugin)
+target_link_libraries(quickshell PRIVATE quickshell-service-polkitplugin Threads::Threads)


### PR DESCRIPTION
The polkit component is missing the pthread lib, causing the bianry cannot be build, so adding the lib fix the problem.