### PR TITLE
feat: expose DbusMenu to QML

### DIFF
--- a/src/dbus/dbusmenu/dbusmenu.hpp
+++ b/src/dbus/dbusmenu/dbusmenu.hpp
@@ -171,10 +171,13 @@ class DBusMenuHandle;
 QDebug operator<<(QDebug debug, const DBusMenuHandle* handle);
 
 class DBusMenuHandle: public menu::QsMenuHandle {
-public:
-	explicit DBusMenuHandle(QObject* parent): menu::QsMenuHandle(parent) {}
+	Q_OBJECT;
+	QML_ELEMENT;
 
-	void setAddress(const QString& service, const QString& path);
+public:
+	explicit DBusMenuHandle(QObject* parent = nullptr): menu::QsMenuHandle(parent) {}
+
+	Q_INVOKABLE void setAddress(const QString& service, const QString& path);
 
 	void refHandle() override;
 	void unrefHandle() override;


### PR DESCRIPTION
Can be used to implement global menus https://github.com/quickshell-mirror/quickshell/issues/170

Not sure if the appmenu component should be exposed by itself as it is done with status icons, given that it might be styled differently etc. Myself I have implemented global menus as a plugin for noctalia shell, and will try to publish it after I make its code somewhat readable

<img width="854" height="208" alt="image" src="https://github.com/user-attachments/assets/a9d895e2-1f39-43cd-8ae2-0b5ba06d392e" />
