### PR TITLE
core: fix inverted inHeader condition in preprocessor

### DIFF
--- a/src/core/scan.cpp
+++ b/src/core/scan.cpp
@@ -118,7 +118,7 @@ bool QmlScanner::scanQmlFile(const QString& path, bool& singleton, bool& interna
 	auto stream = QTextStream(&file);
 	auto imports = QVector<QString>();
 
-	bool inHeader = false;
+	bool inHeader = true;
 	auto ifScopes = QVector<bool>();
 	bool sourceMasked = false;
 	int lineNum = 0;
@@ -177,7 +177,7 @@ bool QmlScanner::scanQmlFile(const QString& path, bool& singleton, bool& interna
 			} else if (!internal && line == "//@ pragma Internal") {
 				internal = true;
 			} else if (line.contains('{')) {
-				inHeader = true;
+				inHeader = false;
 			}
 		}
 


### PR DESCRIPTION
inHeader starts as false after latest commit, which breaks module loading. It should start as true and flip to off after it encounters the first {.

