### PR TITLE
ipc: use deleteLater() in IpcServerConnection to prevent use-after-free

### DIFF
--- a/src/ipc/ipc.cpp
+++ b/src/ipc/ipc.cpp
@@ -61,7 +61,7 @@ IpcServerConnection::IpcServerConnection(QLocalSocket* socket, IpcServer* server
 
 void IpcServerConnection::onDisconnected() {
 	qCInfo(logIpc) << "IPC connection disconnected" << this;
-	delete this;
+	this->deleteLater();
 }
 
 void IpcServerConnection::onReadyRead() {
@@ -88,7 +88,7 @@ void IpcServerConnection::onReadyRead() {
 
 	// async connections reparent
 	if (dynamic_cast<IpcServer*>(this->parent()) != nullptr) {
-		delete this;
+		this->deleteLater();
 	}
 }
 


### PR DESCRIPTION
This PR fixes a SIGSEGV crash that occurs when quickshell processes IPC commands (e.g., via `dms ipc call`).

## The Issue
The crash was caused by a use-after-free error in `IpcServerConnection`.
1. `IpcServerConnection::onReadyRead` is triggered by the underlying `QLocalSocket`'s `readyRead` signal.
2. Inside `onReadyRead`, the code previously called `delete this`.
3. Since `IpcServerConnection` is the parent of the `QLocalSocket`, deleting the connection also destroys the socket.
4. Qt's signal emission loop (`QObject::doActivate`) was still iterating over the socket's connections when the socket was destroyed, leading to a segmentation fault.
 
This issue was consistently reproducible when running under `hardened_malloc`.

## The Fix
Replaced `delete this` with `this->deleteLater()` in both `onReadyRead` and `onDisconnected`. This ensures the object destruction is deferred until control returns to the event loop, allowing the current signal emission to complete safely.

## Verification
Confirmed that `dms ipc call spotlight toggle` no longer crashes the shell.