### PR TITLE
core/proxywindow: create window on visibility for lazily initialized windows

### DIFF
--- a/src/window/proxywindow.cpp
+++ b/src/window/proxywindow.cpp
@@ -288,10 +288,16 @@ void ProxyWindowBase::setVisibleDirect(bool visible) {
 			this->bBackerVisibility = false;
 			this->deleteWindow();
 		}
-	} else if (this->window != nullptr) {
-		if (visible) this->polishItems();
-		this->window->setVisible(visible);
-		this->bBackerVisibility = visible;
+	} else {
+		if (visible && this->window == nullptr) {
+			this->createWindow();
+		}
+
+		if (this->window != nullptr) {
+			if (visible) this->polishItems();
+			this->window->setVisible(visible);
+			this->bBackerVisibility = visible;
+		}
 	}
 }
 


### PR DESCRIPTION
de1bfe028d6982ac9dce08e5063ea5611498b204 introduced a regression for windows where they would not be created if created initially with visible:false. This is a fix for that, by creating them if window is null but visible is true.