### PR TITLE
core: add hasIconTheme mapping

### DIFF
--- a/changelog/next.md
+++ b/changelog/next.md
@@ -24,6 +24,7 @@ set shell id.
 - Added support for grabbing focus from popup windows.
 - Added support for IPC signal listeners.
 - Added Quickshell version checking and version gated preprocessing.
+- Added a way to detect if an icon is from the system icon theme or not.
 
 ## Other Changes
 

--- a/src/core/qmlglobal.cpp
+++ b/src/core/qmlglobal.cpp
@@ -314,6 +314,8 @@ QString QuickshellGlobal::iconPath(const QString& icon, const QString& fallback)
 	return IconImageProvider::requestString(icon, "", fallback);
 }
 
+bool QuickshellGlobal::hasThemeIcon(const QString& icon) { return QIcon::hasThemeIcon(icon); }
+
 bool QuickshellGlobal::hasVersion(qint32 major, qint32 minor, const QStringList& features) {
 	return qs::scan::env::PreprocEnv::hasVersion(major, minor, features);
 }

--- a/src/core/qmlglobal.hpp
+++ b/src/core/qmlglobal.hpp
@@ -202,6 +202,8 @@ public:
 	/// Setting the `fallback` parameter of `iconPath` will attempt to load the fallback
 	/// icon if the requested one could not be loaded.
 	Q_INVOKABLE static QString iconPath(const QString& icon, const QString& fallback);
+	/// Check if specified icon has an available icon in your icon theme
+	Q_INVOKABLE static bool hasThemeIcon(const QString& icon);
 	/// Equivalent to `${Quickshell.configDir}/${path}`
 	Q_INVOKABLE [[nodiscard]] QString shellPath(const QString& path) const;
 	/// > [!WARNING] Deprecated: Renamed to @@shellPath() for clarity.


### PR DESCRIPTION
Adds a mapping to [QIcon::hasIconTheme](https://doc.qt.io/qt-6/qicon.html#hasThemeIcon), useful for checking if an icon provided by systray or similar scenarios is from your icon theme or not, as far as I know there is no way of checking this via quickshell ATM. 