### PR TITLE
nix: use libxcb directly

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -18,7 +18,7 @@
   wayland,
   wayland-protocols,
   wayland-scanner,
-  xorg,
+  libxcb,
   libdrm,
   libgbm ? null,
   vulkan-headers,
@@ -88,7 +88,7 @@
     ++ lib.optional (withWayland && lib.strings.compareVersions qt6.qtbase.version "6.10.0" == -1) qt6.qtwayland
     ++ lib.optionals withWayland [ wayland wayland-protocols ]
     ++ lib.optionals (withWayland && libgbm != null) [ libdrm libgbm vulkan-headers ]
-    ++ lib.optional withX11 xorg.libxcb
+    ++ lib.optional withX11 libxcb
     ++ lib.optional withPam pam
     ++ lib.optional withPipewire pipewire
     ++ lib.optionals withPolkit [ polkit glib ];


### PR DESCRIPTION
```
evaluation warning: The xorg package set has been deprecated, 'xorg.libxcb' has been renamed to 'libxcb'
```
In https://github.com/NixOS/nixpkgs/pull/479724, package set `xorg` has been deprecated.
