### PR TITLE
fix(pipewire): fix volume control for devices without route definitions

### DIFF
--- a/changelog/next.md
+++ b/changelog/next.md
@@ -36,6 +36,7 @@ set shell id.
 
 - Fixed volume control breaking with pipewire pro audio mode.
 - Fixed volume control breaking with bluez streams and potentially others.
+- Fixed volume control breaking for devices without route definitions.
 - Fixed escape sequence handling in desktop entries.
 - Fixed volumes not initializing if a pipewire device was already loaded before its node.
 - Fixed hyprland active toplevel not resetting after window closes.

--- a/src/services/pipewire/device.cpp
+++ b/src/services/pipewire/device.cpp
@@ -141,6 +141,10 @@ bool PwDevice::tryLoadVolumeProps(qint32 routeDevice, PwVolumeProps& volumeProps
 	return true;
 }
 
+bool PwDevice::hasRouteDevice(qint32 routeDevice) const {
+	return this->routeDeviceIndexes.contains(routeDevice);
+}
+
 void PwDevice::polled() {
 	// It is far more likely that the list content has not come in yet than it having no entries,
 	// and there isn't a way to check in the case that there *aren't* actually any entries.

--- a/src/services/pipewire/device.hpp
+++ b/src/services/pipewire/device.hpp
@@ -12,12 +12,14 @@
 #include <spa/pod/builder.h>
 
 #include "core.hpp"
-#include "node.hpp"
 #include "registry.hpp"
 
 namespace qs::service::pipewire {
 
 class PwDevice;
+
+// Forward declare to avoid circular dependency with node.hpp
+struct PwVolumeProps;
 
 class PwDevice: public PwBindable<pw_device, PW_TYPE_INTERFACE_Device, PW_VERSION_DEVICE> {
 	Q_OBJECT;
@@ -33,6 +35,7 @@ public:
 	[[nodiscard]] bool waitingForDevice() const;
 
 	[[nodiscard]] bool tryLoadVolumeProps(qint32 routeDevice, PwVolumeProps& volumeProps);
+	[[nodiscard]] bool hasRouteDevice(qint32 routeDevice) const;
 
 signals:
 	void deviceReady();

--- a/src/services/pipewire/node.cpp
+++ b/src/services/pipewire/node.cpp
@@ -429,6 +429,10 @@ void PwNodeBoundAudio::setMuted(bool muted) {
 }
 
 float PwNodeBoundAudio::averageVolume() const {
+	if (this->mVolumes.isEmpty()) {
+		return 0.0f;
+	}
+
 	float total = 0;
 
 	for (auto volume: this->mVolumes) {
@@ -572,22 +576,28 @@ PwVolumeProps PwVolumeProps::parseSpaPod(const spa_pod* param) {
 	const auto* muteProp = spa_pod_find_prop(param, nullptr, SPA_PROP_mute);
 	const auto* volumeStepProp = spa_pod_find_prop(param, nullptr, SPA_PROP_volumeStep);
 
-	const auto* volumes = reinterpret_cast<const spa_pod_array*>(&volumesProp->value);
-	const auto* channels = reinterpret_cast<const spa_pod_array*>(&channelsProp->value);
-
-	spa_pod* iter = nullptr;
-	SPA_POD_ARRAY_FOREACH(volumes, iter) {
-		// Cubing behavior found in MPD source, and appears to corrospond to everyone else's measurements correctly.
-		auto linear = *reinterpret_cast<float*>(iter);
-		auto visual = std::cbrt(linear);
-		props.volumes.push_back(visual);
+	if (volumesProp) {
+		const auto* volumes = reinterpret_cast<const spa_pod_array*>(&volumesProp->value);
+		spa_pod* iter = nullptr;
+		SPA_POD_ARRAY_FOREACH(volumes, iter) {
+			// Cubing behavior found in MPD source, and appears to corrospond to everyone else's measurements correctly.
+			auto linear = *reinterpret_cast<float*>(iter);
+			auto visual = std::cbrt(linear);
+			props.volumes.push_back(visual);
+		}
 	}
 
-	SPA_POD_ARRAY_FOREACH(channels, iter) {
-		props.channels.push_back(*reinterpret_cast<PwAudioChannel::Enum*>(iter));
+	if (channelsProp) {
+		const auto* channels = reinterpret_cast<const spa_pod_array*>(&channelsProp->value);
+		spa_pod* iter = nullptr;
+		SPA_POD_ARRAY_FOREACH(channels, iter) {
+			props.channels.push_back(*reinterpret_cast<PwAudioChannel::Enum*>(iter));
+		}
 	}
 
-	spa_pod_get_bool(&muteProp->value, &props.mute);
+	if (muteProp) {
+		spa_pod_get_bool(&muteProp->value, &props.mute);
+	}
 
 	if (volumeStepProp) {
 		spa_pod_get_float(&volumeStepProp->value, &props.volumeStep);

--- a/src/services/pipewire/node.hpp
+++ b/src/services/pipewire/node.hpp
@@ -15,6 +15,7 @@
 #include <spa/pod/pod.h>
 
 #include "core.hpp"
+#include "device.hpp"
 #include "registry.hpp"
 
 namespace qs::service::pipewire {
@@ -249,7 +250,9 @@ public:
 	bool proAudio = false;
 
 	[[nodiscard]] bool shouldUseDevice() const {
-		return this->device && !this->proAudio && this->routeDevice != -1;
+		if (!this->device || this->proAudio || this->routeDevice == -1) return false;
+		// Only use device control if the device actually has route indexes for this routeDevice
+		return this->device->hasRouteDevice(this->routeDevice);
 	}
 
 signals:


### PR DESCRIPTION
Fix multiple issues that prevented volume control from working for certain audio devices (particularly headphones) where the ALSA/Pipewire device has no route definitions.

Backend fixes:
- Fix division by zero in PwNodeBoundAudio::averageVolume() - returns 0.0f when mVolumes vector is empty instead of causing NaN/Infinity
- Fix null pointer dereferences in PwVolumeProps::parseSpaPod() by adding null checks for volumesProp, channelsProp, and muteProp before access
- Add PwDevice::hasRouteDevice() method to check if a routeDevice exists
- Modify PwNode::shouldUseDevice() to check hasRouteDevice() - this prevents nodes from attempting to use device control when the device has no route definitions, forcing fallback to node-level SPA param control
- Add forward declaration for PwVolumeProps in device.hpp to avoid circular dependency (device.hpp includes node.hpp which includes device.hpp)

Root cause: Devices like the Sennheiser GSX 1000 (id=56) have routeDevice=0 but no route definitions in routeDeviceIndexes. The original code would skip node-level volume updates in favor of device updates that never came, resulting in no volume events being emitted.

Fix: Nodes now use node-level control when hasRouteDevice() returns false, ensuring volume events are properly emitted via SPA_PROP_Props.