### PR TITLE
Crash fix: Sometimes output can be nullptr such as when it is a placeholder

### DIFF
--- a/changelog/next.md
+++ b/changelog/next.md
@@ -46,6 +46,7 @@ set shell id.
 - Fixed asynchronous loaders not working before window creation.
 - Fixed memory leak in IPC handlers.
 - Fixed ClippingRectangle related crashes.
+- Fixed crashes when monitors are unplugged.
 
 ## Packaging Changes
 

--- a/src/wayland/session_lock/surface.cpp
+++ b/src/wayland/session_lock/surface.cpp
@@ -28,7 +28,7 @@ QSWaylandSessionLockSurface::QSWaylandSessionLockSurface(QtWaylandClient::QWayla
 	wl_output* output = nullptr; // NOLINT (include)
 	auto* waylandScreen = dynamic_cast<QtWaylandClient::QWaylandScreen*>(qwindow->screen()->handle());
 
-	if (waylandScreen != nullptr) {
+	if (waylandScreen != nullptr && !waylandScreen->isPlaceholder() && waylandScreen->output()) {
 		output = waylandScreen->output();
 	} else {
 		qFatal() << "Session lock screen does not corrospond to a real screen. Force closing window";

--- a/src/wayland/wlr_layershell/surface.cpp
+++ b/src/wayland/wlr_layershell/surface.cpp
@@ -143,11 +143,11 @@ LayerSurface::LayerSurface(LayerShellIntegration* shell, QtWaylandClient::QWayla
 		auto* waylandScreen =
 		    dynamic_cast<QtWaylandClient::QWaylandScreen*>(qwindow->screen()->handle());
 
-		if (waylandScreen != nullptr) {
+		if (waylandScreen != nullptr && !waylandScreen->isPlaceholder() && waylandScreen->output()) {
 			output = waylandScreen->output();
 		} else {
 			qWarning()
-			    << "Layershell screen does not corrospond to a real screen. Letting the compositor pick.";
+			    << "Layershell screen does not correspond to a real screen. Letting the compositor pick.";
 		}
 	}
 


### PR DESCRIPTION
I am using Niri and Noctalia-Shell. Was running into an issue that sometimes when my monitor was off Noctalia-Shell would crash. I can easily reproduce the issue by quickly replugging my hdmi on the monitor side 5-10 times. Below is an example stacktrace. Note that also in the same state once quickshell itself stops crashing any launched process will crash in qt for the same reason. I put a patch in for that in qtbase [here](https://github.com/qt/qtbase/pull/136). Additional context in https://github.com/noctalia-dev/noctalia-shell/issues/1822.



```
Thread 1 (Thread 0x7f47182dd540 (LWP 143406)):
#0  0x00007f471f7c9ce4 in wl_proxy_get_listener () from /usr/bin/../lib/libwayland-client.so.0
#1  0x00007f471ef9a3b2 in QtWayland::wl_output::fromObject (object=0x0) at /usr/src/debug/qt6-base/build/src/plugins/platforms/wayland/qwayland-wayland.cpp:2341
#2  QtWaylandClient::QWaylandScreen::fromWlOutput (output=0x0) at /usr/src/debug/qt6-base/qtbase/src/plugins/platforms/wayland/qwaylandscreen.cpp:244
#3  QtWaylandClient::QWaylandSurface::surface_enter (this=0x7f470861f8b0, output=0x0) at /usr/src/debug/qt6-base/qtbase/src/plugins/platforms/wayland/qwaylandsurface.cpp:58
#4  0x00007f471f75743e in ?? () from /usr/lib/libffi.so.8
#5  0x00007f471f753a5d in ?? () from /usr/lib/libffi.so.8
#6  0x00007f471f7567ce in ffi_call () from /usr/lib/libffi.so.8
#7  0x00007f471f7c9519 in ?? () from /usr/bin/../lib/libwayland-client.so.0
#8  0x00007f471f7ca429 in ?? () from /usr/bin/../lib/libwayland-client.so.0
#9  0x00007f471f7ca80b in wl_display_dispatch_queue_pending () from /usr/bin/../lib/libwayland-client.so.0
#10 0x00007f471ef629a2 in QtWaylandClient::QWaylandDisplay::qt_static_metacall (_o=<optimized out>, _c=<optimized out>, _id=<optimized out>, _a=<optimized out>) at /usr/src/debug/qt6-base/qtbase/src/plugins/platforms/wayland/qwaylanddisplay.cpp:229
#11 0x00007f471cdd92da in doActivate<false> (sender=<optimized out>, signal_index=<optimized out>, argv=<optimized out>) at /usr/src/debug/qt6-base/qtbase/src/corelib/kernel/qobject.cpp:4284
#12 0x00007f471d04fcf5 in QAbstractEventDispatcher::awake (this=0x7f4717e72560) at /usr/src/debug/qt6-base/build/src/corelib/Core_autogen/include/moc_qabstracteventdispatcher.cpp:128
#13 QEventDispatcherGlib::processEvents (this=0x7f4717e72560, flags=...) at /usr/src/debug/qt6-base/qtbase/src/corelib/kernel/qeventdispatcher_glib.cpp:406
#14 0x00007f471cd76cf6 in QEventLoop::processEvents (this=0x7ffc00726260, flags=...) at /usr/src/debug/qt6-base/qtbase/src/corelib/kernel/qeventloop.cpp:104
#15 QEventLoop::exec (this=0x7ffc00726260, flags=...) at /usr/src/debug/qt6-base/qtbase/src/corelib/kernel/qeventloop.cpp:186
#16 0x00007f471cd709f1 in QCoreApplication::exec () at /usr/src/debug/qt6-base/qtbase/src/corelib/kernel/qcoreapplication.cpp:1452
#17 0x0000555af151b905 in ?? ()
#18 0x0000555af150dab0 in ?? ()
#19 0x0000555af1511a0c in ?? ()
#20 0x0000555af15011a9 in ?? ()
#21 0x00007f471c427c0e in ?? () from /usr/bin/../lib/libc.so.6
#22 0x00007f471c427d4b in __libc_start_main () from /usr/bin/../lib/libc.so.6
#23 0x0000555af1503575 in ?? ()
(gdb)
```