### PR TITLE
core/proxywindow: expose updatesEnabled property

### DIFF
--- a/src/window/proxywindow.cpp
+++ b/src/window/proxywindow.cpp
@@ -223,6 +223,7 @@ void ProxyWindowBase::completeWindow() {
 	this->trySetHeight(this->implicitHeight());
 	this->setColor(this->mColor);
 	this->updateMask();
+	QQuickWindowPrivate::get(this->window)->updatesEnabled = this->mUpdatesEnabled;
 
 	// notify initial / post-connection geometry
 	emit this->xChanged();
@@ -477,6 +478,19 @@ void ProxyWindowBase::setSurfaceFormat(QsSurfaceFormat format) {
 
 	this->qsSurfaceFormat = format;
 	emit this->surfaceFormatChanged();
+}
+
+bool ProxyWindowBase::updatesEnabled() const { return this->mUpdatesEnabled; }
+
+void ProxyWindowBase::setUpdatesEnabled(bool updatesEnabled) {
+	if (updatesEnabled == this->mUpdatesEnabled) return;
+	this->mUpdatesEnabled = updatesEnabled;
+
+	if (this->window != nullptr) {
+		QQuickWindowPrivate::get(this->window)->updatesEnabled = updatesEnabled;
+	}
+
+	emit this->updatesEnabledChanged();
 }
 
 qreal ProxyWindowBase::devicePixelRatio() const {

--- a/src/window/proxywindow.hpp
+++ b/src/window/proxywindow.hpp
@@ -57,6 +57,7 @@ class ProxyWindowBase: public Reloadable {
 	Q_PROPERTY(QObject* windowTransform READ windowTransform NOTIFY windowTransformChanged);
 	Q_PROPERTY(bool backingWindowVisible READ isVisibleDirect NOTIFY backerVisibilityChanged);
 	Q_PROPERTY(QsSurfaceFormat surfaceFormat READ surfaceFormat WRITE setSurfaceFormat NOTIFY surfaceFormatChanged);
+	Q_PROPERTY(bool updatesEnabled READ updatesEnabled WRITE setUpdatesEnabled NOTIFY updatesEnabledChanged);
 	Q_PROPERTY(QQmlListProperty<QObject> data READ data);
 	// clang-format on
 	Q_CLASSINFO("DefaultProperty", "data");
@@ -140,6 +141,9 @@ public:
 	[[nodiscard]] QsSurfaceFormat surfaceFormat() const { return this->qsSurfaceFormat; }
 	void setSurfaceFormat(QsSurfaceFormat format);
 
+	[[nodiscard]] bool updatesEnabled() const;
+	void setUpdatesEnabled(bool updatesEnabled);
+
 	[[nodiscard]] QObject* windowTransform() const { return nullptr; } // NOLINT
 
 	[[nodiscard]] QQmlListProperty<QObject> data();
@@ -163,6 +167,7 @@ signals:
 	void colorChanged();
 	void maskChanged();
 	void surfaceFormatChanged();
+	void updatesEnabledChanged();
 	void polished();
 
 protected slots:
@@ -187,6 +192,7 @@ protected:
 	ProxyWindowContentItem* mContentItem = nullptr;
 	bool reloadComplete = false;
 	bool ranLints = false;
+	bool mUpdatesEnabled = true;
 	QsSurfaceFormat qsSurfaceFormat;
 	QSurfaceFormat mSurfaceFormat;
 

--- a/src/window/windowinterface.cpp
+++ b/src/window/windowinterface.cpp
@@ -127,6 +127,9 @@ void WindowInterface::setMask(PendingRegion* mask) const { this->proxyWindow()->
 QsSurfaceFormat WindowInterface::surfaceFormat() const { return this->proxyWindow()->surfaceFormat(); };
 void WindowInterface::setSurfaceFormat(QsSurfaceFormat format) const { this->proxyWindow()->setSurfaceFormat(format); };
 
+bool WindowInterface::updatesEnabled() const { return this->proxyWindow()->updatesEnabled(); };
+void WindowInterface::setUpdatesEnabled(bool updatesEnabled) const { this->proxyWindow()->setUpdatesEnabled(updatesEnabled); };
+
 QQmlListProperty<QObject> WindowInterface::data() const { return this->proxyWindow()->data(); };
 // clang-format on
 
@@ -148,6 +151,7 @@ void WindowInterface::connectSignals() const {
 	QObject::connect(window, &ProxyWindowBase::colorChanged, this, &WindowInterface::colorChanged);
 	QObject::connect(window, &ProxyWindowBase::maskChanged, this, &WindowInterface::maskChanged);
 	QObject::connect(window, &ProxyWindowBase::surfaceFormatChanged, this, &WindowInterface::surfaceFormatChanged);
+	QObject::connect(window, &ProxyWindowBase::updatesEnabledChanged, this, &WindowInterface::updatesEnabledChanged);
 	// clang-format on
 }
 

--- a/src/window/windowinterface.hpp
+++ b/src/window/windowinterface.hpp
@@ -143,6 +143,12 @@ class WindowInterface: public Reloadable {
 	///
 	/// > [!NOTE] The surface format cannot be changed after the window is created.
 	Q_PROPERTY(QsSurfaceFormat surfaceFormat READ surfaceFormat WRITE setSurfaceFormat NOTIFY surfaceFormatChanged);
+	/// If the window should receive render updates. Defaults to true.
+	///
+	/// When set to false, the window will not re-render in response to animations
+	/// or other visual updates from other windows. This is useful for static windows
+	/// such as wallpapers that do not need to update frequently, saving GPU cycles.
+	Q_PROPERTY(bool updatesEnabled READ updatesEnabled WRITE setUpdatesEnabled NOTIFY updatesEnabledChanged);
 	Q_PROPERTY(QQmlListProperty<QObject> data READ data);
 	// clang-format on
 	Q_CLASSINFO("DefaultProperty", "data");
@@ -231,6 +237,9 @@ public:
 	[[nodiscard]] QsSurfaceFormat surfaceFormat() const;
 	void setSurfaceFormat(QsSurfaceFormat format) const;
 
+	[[nodiscard]] bool updatesEnabled() const;
+	void setUpdatesEnabled(bool updatesEnabled) const;
+
 	[[nodiscard]] QQmlListProperty<QObject> data() const;
 
 	static QsWindowAttached* qmlAttachedProperties(QObject* object);
@@ -258,6 +267,7 @@ signals:
 	void colorChanged();
 	void maskChanged();
 	void surfaceFormatChanged();
+	void updatesEnabledChanged();
 
 protected:
 	void connectSignals() const;


### PR DESCRIPTION
Exposes `updatesEnabled` property from QQuickWindow 

Seems like QtQuick repaints unchanged surfaces constantly in its animation render loop, even if they are unchanged. This allows generally disabling repaints on surfaces.