### PR TITLE
fix (dmabuf): force alpha=1.0 for XRGB formats in Vulkan dmabuf path   

### DIFF
--- a/src/wayland/buffer/CMakeLists.txt
+++ b/src/wayland/buffer/CMakeLists.txt
@@ -12,7 +12,7 @@ qt_add_library(quickshell-wayland-buffer STATIC
 wl_proto(wlp-linux-dmabuf linux-dmabuf-v1 "${WAYLAND_PROTOCOLS}/stable/linux-dmabuf")
 
 target_link_libraries(quickshell-wayland-buffer PRIVATE
-	Qt::Quick Qt::QuickPrivate Qt::WaylandClient Qt::WaylandClientPrivate wayland-client
+	Qt::Quick Qt::QuickPrivate Qt::GuiPrivate Qt::WaylandClient Qt::WaylandClientPrivate wayland-client
 	PkgConfig::dmabuf-deps
 	wlp-linux-dmabuf
 	Vulkan::Headers


### PR DESCRIPTION
XRGB DRM formats have undefined alpha bytes. EGL silently forces alpha to 1.0 for these, Vulkan doesn't, so the garbage alpha leaks through and causes transparent screencopy textures on some GPUs (it seems to depend on drivers and star aligment). 

Uses a VkImageView component swizzle on the alpha channel for opaque formats, which is basically what EGL does. Also flips format preference to ARGB over XRGB for when qucikshell picks the format. `Qt::GuiPrivate` was needed for `QVkTexture` access