### PR TITLE
service/greetd: fix socket buffer reading

### DIFF
--- a/src/services/greetd/connection.cpp
+++ b/src/services/greetd/connection.cpp
@@ -42,11 +42,11 @@ GreetdConnection::GreetdConnection() {
 	this->mAvailable = true;
 
 	// clang-format off
-	QObject::connect(&this->socket, &QLocalSocket::connected, this, &GreetdConnection::onSocketConnected);
-	QObject::connect(&this->socket, &QLocalSocket::readyRead, this, &GreetdConnection::onSocketReady);
+	QObject::connect(&this->mSocket, &QLocalSocket::connected, this, &GreetdConnection::onSocketConnected);
+	QObject::connect(&this->mSocket, &QLocalSocket::readyRead, this, &GreetdConnection::onSocketReady);
 	// clang-format on
 
-	this->socket.connectToServer(socket, QLocalSocket::ReadWrite);
+	this->mSocket.connectToServer(socket, QLocalSocket::ReadWrite);
 }
 
 void GreetdConnection::createSession(QString user) {
@@ -103,7 +103,7 @@ bool GreetdConnection::isAvailable() const { return this->mAvailable; }
 GreetdState::Enum GreetdConnection::state() const { return this->mState; }
 
 void GreetdConnection::setActive(bool active) {
-	if (this->socket.state() == QLocalSocket::ConnectedState) {
+	if (this->mSocket.state() == QLocalSocket::ConnectedState) {
 		this->mTargetActive = active;
 		if (active == (this->mState != GreetdState::Inactive)) return;
 
@@ -160,11 +160,23 @@ void GreetdConnection::onSocketError(QLocalSocket::LocalSocketError error) {
 }
 
 void GreetdConnection::onSocketReady() {
-	qint32 length = 0;
+	while (true) {
+		if (this->mSocketExpectedLength <= 0) {
+			if (this->mSocket.bytesAvailable() < static_cast<qsizetype>(sizeof(qint32))) return;
 
-	this->socket.read(reinterpret_cast<char*>(&length), sizeof(qint32));
+			this->mSocket.read(reinterpret_cast<char*>(&this->mSocketExpectedLength), sizeof(qint32));
+		}
 
-	auto text = this->socket.read(length);
+		if (this->mSocket.bytesAvailable() < this->mSocketExpectedLength) return;
+
+		const auto text = this->mSocket.read(this->mSocketExpectedLength);
+		this->mSocketExpectedLength = 0;
+
+		this->handleMessage(text);
+	}
+}
+
+void GreetdConnection::handleMessage(const QByteArray& text) {
 	auto json = QJsonDocument::fromJson(text).object();
 	auto type = json.value("type").toString();
 
@@ -253,10 +265,10 @@ void GreetdConnection::sendRequest(const QJsonObject& json) {
 		                             << QJsonDocument(debugJson).toJson(QJsonDocument::Compact);
 	}
 
-	this->socket.write(reinterpret_cast<char*>(&length), sizeof(qint32));
+	this->mSocket.write(reinterpret_cast<char*>(&length), sizeof(qint32));
 
-	this->socket.write(text);
-	this->socket.flush();
+	this->mSocket.write(text);
+	this->mSocket.flush();
 }
 
 GreetdConnection* GreetdConnection::instance() {

--- a/src/services/greetd/connection.hpp
+++ b/src/services/greetd/connection.hpp
@@ -62,6 +62,7 @@ private slots:
 private:
 	explicit GreetdConnection();
 
+	void handleMessage(const QByteArray& text);
 	void sendRequest(const QJsonObject& json);
 	void setActive(bool active);
 	void setInactive();
@@ -73,5 +74,6 @@ private:
 	QString mMessage;
 	bool mResponseRequired = false;
 	QString mUser;
-	QLocalSocket socket;
+	QLocalSocket mSocket;
+	qint32 mSocketExpectedLength = 0;
 };


### PR DESCRIPTION
# service/greetd: fix socket buffer reading

The current implementation assumes that `QLocalSocket::readyRead` provides **atomic reads**.
However, this is not the case for the `greetd` socket, since its UNIX socket type is `SOCK_STREAM`, which **does not guarantee message boundary preservation** (unlike `SOCK_DGRAM`).

This issue is usually not apparent because most machines are fast enough that short messages often behave _as if_ they were atomic. In practice, this makes the behavior dependent on CPU scheduling and timing.

## Fix

The fix decouples message handling from the `readyRead` event. Data is now checked and only forwarded to the message handler once enough bytes have been received to form a complete message.

Since it is also possible (although rare) for multiple messages to arrive within a single `QLocalSocket::readyRead` event, the parsing logic is executed in a loop until the buffer no longer contains a complete message.

Additionally, I renamed the member `socket` to `mSocket` to match the naming convention used by the other class attributes.

---

## Demonstration

Logs from Quickshell:

**Note:** The `"bytes"` logs were added for debugging.

```txt
DEBUG quickshell.service.greetd: Sending greetd request: {"type":"create_session","username":"vanisher"}
 INFO: Tried to read 4 bytes out of 4 available
ERROR: Tried to read 80 bytes out of 0 available
DEBUG quickshell.service.greetd: Received greetd response:
ERROR quickshell.service.greetd: Received unexpected greetd response ""
DEBUG quickshell.service.greetd: Sending greetd request: {"type":"cancel_session"}
 INFO: Tried to read 4 bytes out of 102 available
ERROR: Tried to read 2037654139 bytes out of 98 available
DEBUG quickshell.service.greetd: Received greetd response: pe":"auth_message","auth_message_type":"secret","auth_message":"Password: "}{"type":"success"}
ERROR quickshell.service.greetd: Received unexpected greetd response "pe\":\"auth_message\",\"auth_message_type\":\"secret\",\"auth_message\":\"Password: \"}\x12\x00\x00\x00{\"type\":\"success\"}"
```

**First read**

Only the payload length is received, without the payload itself. This leaves 80 bytes of leftover data for the next read.

**Second read**

The parser then attempts to interpret `{"ty` (`0x7974227B`) as an `i32`, which results in `2037654139`. It then tries to read that many bytes, mixing the remainder of the previous message with the entire next message.

I also recorded a short demonstration: [https://youtu.be/FLgoRmsbgv0](https://youtu.be/FLgoRmsbgv0)

---

## Related observations

This assumption of **message-aligned reads** may also affect other parts of the code.

For example, in `src/wayland/hyprland/ipc/connection.cpp`, the response callback in `HyprlandIpc::makeRequest` may potentially suffer from the same issue:

```cpp
auto responseCallback = [requestSocket, callback]() {
    auto response = requestSocket->readAll();
    callback(true, std::move(response));
    delete requestSocket;
};
```

Since this reads whatever is available at the time of the event, it may receive a partial response if the message arrives in multiple chunks.

The events socket does not have this problem because it relies on newline-delimited messages, which ensures complete line reads:

```cpp
void HyprlandIpc::eventSocketReady() {
    while (true) {
        auto rawEvent = this->eventSocket.readLine();
        if (rawEvent.isEmpty()) break;

        // [...]
    }
}
```

Since I am not very familiar with these parts of the codebase, I did not attempt to address them in this PR.
