### PR TITLE
wayland(toplevel): fix empty state

### DIFF
--- a/changelog/next.md
+++ b/changelog/next.md
@@ -50,6 +50,7 @@ set shell id.
 - Fixed ClippingRectangle related crashes.
 - Fixed crashes when monitors are unplugged.
 - Fixed crashes when default pipewire devices are lost.
+- Fixed ToplevelManager not clearing activeToplevel on deactivation.
 - Desktop action order is now preserved.
 
 ## Packaging Changes

--- a/src/wayland/toplevel_management/qml.cpp
+++ b/src/wayland/toplevel_management/qml.cpp
@@ -161,7 +161,11 @@ void ToplevelManager::onToplevelReady(impl::ToplevelHandle* handle) {
 
 void ToplevelManager::onToplevelActiveChanged() {
 	auto* toplevel = qobject_cast<Toplevel*>(this->sender());
-	if (toplevel->activated()) this->setActiveToplevel(toplevel);
+	if (toplevel->activated()) {
+		this->setActiveToplevel(toplevel);
+	} else if (toplevel == this->mActiveToplevel) {
+		this->setActiveToplevel(nullptr);
+	}
 }
 
 void ToplevelManager::onToplevelClosed() {


### PR DESCRIPTION
Right now an empty active toplevel has the title of the last active toplevel.