### PR TITLE
core/desktopentry: add support for xdg-terminal-exec

### DIFF
--- a/src/core/desktopentry.cpp
+++ b/src/core/desktopentry.cpp
@@ -124,6 +124,8 @@ ParsedDesktopEntryData DesktopEntry::parseText(const QString& id, const QString&
 				else if (key == "StartupWMClass") data.startupClass = value;
 				else if (key == "NoDisplay") data.noDisplay = value == "true";
 				else if (key == "Hidden") data.hidden = value == "true";
+				else if (key == "OnlyShowIn") data.onlyShowIn = value.split(u';', Qt::SkipEmptyParts);
+				else if (key == "NotShowIn") data.notShowIn = value.split(u';', Qt::SkipEmptyParts);
 				else if (key == "Comment") data.comment = value;
 				else if (key == "Icon") data.icon = value;
 				else if (key == "Exec") {
@@ -224,6 +226,8 @@ void DesktopEntry::updateState(const ParsedDesktopEntryData& newState) {
 	this->bGenericName = newState.genericName;
 	this->bStartupClass = newState.startupClass;
 	this->bNoDisplay = newState.noDisplay;
+	this->bOnlyShowIn = newState.onlyShowIn;
+	this->bNotShowIn = newState.notShowIn;
 	this->bComment = newState.comment;
 	this->bIcon = newState.icon;
 	this->bExecString = newState.execString;
@@ -618,74 +622,94 @@ void DesktopEntryManager::onScanCompleted(const QList<ParsedDesktopEntryData>& s
 	});
 
 	auto oldEntries = this->desktopEntries;
-	auto newEntries = QHash<QString, DesktopEntry*>();
-	auto newLowercaseEntries = QHash<QString, DesktopEntry*>();
 
-	for (const auto& data: scanResults) {
-		auto lowerId = data.id.toLower();
+	{
+		auto newEntries = QHash<QString, DesktopEntry*>();
+		auto newEntriesLowercase = QHash<QString, DesktopEntry*>();
 
-		if (data.hidden) {
-			if (auto* victim = newEntries.take(data.id)) victim->deleteLater();
-			newLowercaseEntries.remove(lowerId);
+		for (const auto& data: scanResults) {
+			auto lowerId = data.id.toLower();
+
+			if (data.hidden) {
+				if (auto* victim = newEntries.take(data.id)) victim->deleteLater();
+				newEntriesLowercase.remove(lowerId);
+
+				if (auto it = oldEntries.find(data.id); it != oldEntries.end()) {
+					it.value()->deleteLater();
+					oldEntries.erase(it);
+				}
+
+				qCDebug(logDesktopEntry) << "Masking hidden desktop entry" << data.id;
+				continue;
+			}
+
+			DesktopEntry* dentry = nullptr;
 
 			if (auto it = oldEntries.find(data.id); it != oldEntries.end()) {
-				it.value()->deleteLater();
+				dentry = it.value();
 				oldEntries.erase(it);
+				dentry->updateState(data);
+			} else {
+				dentry = new DesktopEntry(data.id, this);
+				dentry->updateState(data);
 			}
 
-			qCDebug(logDesktopEntry) << "Masking hidden desktop entry" << data.id;
-			continue;
-		}
-
-		DesktopEntry* dentry = nullptr;
-
-		if (auto it = oldEntries.find(data.id); it != oldEntries.end()) {
-			dentry = it.value();
-			oldEntries.erase(it);
-			dentry->updateState(data);
-		} else {
-			dentry = new DesktopEntry(data.id, this);
-			dentry->updateState(data);
-		}
-
-		if (!dentry->isValid()) {
-			qCDebug(logDesktopEntry) << "Skipping desktop entry" << data.id;
-			if (!oldEntries.contains(data.id)) {
-				dentry->deleteLater();
+			if (!dentry->isValid()) {
+				qCDebug(logDesktopEntry) << "Skipping desktop entry" << data.id;
+				if (!oldEntries.contains(data.id)) {
+					dentry->deleteLater();
+				}
+				continue;
 			}
-			continue;
+
+			qCDebug(logDesktopEntry) << "Found desktop entry" << data.id;
+
+			auto conflictingId = newEntries.contains(data.id);
+
+			if (conflictingId) {
+				qCDebug(logDesktopEntry) << "Replacing old entry for" << data.id;
+				if (auto* victim = newEntries.take(data.id)) victim->deleteLater();
+				newEntriesLowercase.remove(lowerId);
+			}
+
+			newEntries.insert(data.id, dentry);
+
+			if (newEntriesLowercase.contains(lowerId)) {
+				qCInfo(logDesktopEntry).nospace()
+				    << "Multiple desktop entries have the same lowercased id " << lowerId
+				    << ". This can cause ambiguity when byId requests are not made with the correct case "
+				       "already.";
+
+				newEntriesLowercase.remove(lowerId);
+			}
+
+			newEntriesLowercase.insert(lowerId, dentry);
 		}
 
-		qCDebug(logDesktopEntry) << "Found desktop entry" << data.id;
-
-		auto conflictingId = newEntries.contains(data.id);
-
-		if (conflictingId) {
-			qCDebug(logDesktopEntry) << "Replacing old entry for" << data.id;
-			if (auto* victim = newEntries.take(data.id)) victim->deleteLater();
-			newLowercaseEntries.remove(lowerId);
-		}
-
-		newEntries.insert(data.id, dentry);
-
-		if (newLowercaseEntries.contains(lowerId)) {
-			qCInfo(logDesktopEntry).nospace()
-			    << "Multiple desktop entries have the same lowercased id " << lowerId
-			    << ". This can cause ambiguity when byId requests are not made with the correct case "
-			       "already.";
-
-			newLowercaseEntries.remove(lowerId);
-		}
-
-		newLowercaseEntries.insert(lowerId, dentry);
+		this->desktopEntries = newEntries;
+		this->lowercaseDesktopEntries = newEntriesLowercase;
 	}
 
-	this->desktopEntries = newEntries;
-	this->lowercaseDesktopEntries = newLowercaseEntries;
+	auto desktopNames = qEnvironmentVariable("XDG_CURRENT_DESKTOP").split(':', Qt::SkipEmptyParts);
+	auto showInCurrentDesktop = [&desktopNames](const DesktopEntry* entry) {
+		const auto& onlyShowIn = entry->bOnlyShowIn.value();
+		const auto& notShowIn = entry->bNotShowIn.value();
+
+		for (const auto& name: desktopNames) {
+			if (onlyShowIn.has_value() && onlyShowIn->contains(name)) return true;
+			if (notShowIn.has_value() && notShowIn->contains(name)) return false;
+		}
+
+		return !onlyShowIn.has_value();
+	};
 
 	auto newApplications = QVector<DesktopEntry*>();
-	for (auto* entry: this->desktopEntries.values())
-		if (!entry->bNoDisplay) newApplications.append(entry);
+	for (auto* entry: this->desktopEntries.values()) {
+		if (entry->bNoDisplay) continue;
+		if (!showInCurrentDesktop(entry)) continue;
+
+		newApplications.append(entry);
+	}
 
 	this->mApplications.diffUpdate(newApplications);
 
@@ -904,6 +928,7 @@ void DesktopEntryManager::onScanCompleted(const QList<ParsedDesktopEntryData>& s
 		for (auto* entry: fallbackEntries) {
 			if (seenExplicitIds.contains(entry->mId)) continue;
 			if (!isValidTerminal(entry, termDebug)) continue;
+			if (!showInCurrentDesktop(entry)) continue;
 			if (excludedIds.contains(entry->mId)) continue;
 
 			addResolved(entry, entry->bCommand.value());

--- a/src/core/desktopentry.cpp
+++ b/src/core/desktopentry.cpp
@@ -612,6 +612,39 @@ const QStringList& DesktopEntryManager::desktopPaths() {
 	return paths;
 }
 
+const QStringList& DesktopEntryManager::terminalConfigPaths() {
+	static const auto paths = []() {
+		auto configDirs = QStringList();
+
+		auto configHome = qEnvironmentVariable("XDG_CONFIG_HOME");
+		if (configHome.isEmpty() && qEnvironmentVariableIsSet("HOME"))
+			configHome = qEnvironmentVariable("HOME") + "/.config";
+		if (!configHome.isEmpty()) configDirs.append(configHome);
+
+		auto configDirsStr = qEnvironmentVariable("XDG_CONFIG_DIRS");
+		if (configDirsStr.isEmpty()) configDirsStr = "/etc/xdg";
+		for (const auto& dir: configDirsStr.split(':', Qt::SkipEmptyParts)) configDirs.append(dir);
+
+		auto dataDirs = qEnvironmentVariable("XDG_DATA_DIRS");
+		if (dataDirs.isEmpty()) dataDirs = "/usr/local/share:/usr/share";
+		for (const auto& dir: dataDirs.split(':', Qt::SkipEmptyParts))
+			configDirs.append(dir + "/xdg-terminal-exec");
+
+		auto configPaths = QStringList();
+		auto desktopNames = qEnvironmentVariable("XDG_CURRENT_DESKTOP").split(':', Qt::SkipEmptyParts);
+		for (const auto& dir: configDirs) {
+			for (const auto& name: desktopNames) {
+				configPaths.append(dir + "/" + name.toLower() + "-xdg-terminals.list");
+			}
+			configPaths.append(dir + "/xdg-terminals.list");
+		}
+
+		return configPaths;
+	}();
+
+	return paths;
+}
+
 void DesktopEntryManager::onScanCompleted(const QList<ParsedDesktopEntryData>& scanResults) {
 	auto guard = qScopeGuard([this] {
 		this->scanInProgress = false;
@@ -728,24 +761,6 @@ void DesktopEntryManager::onScanCompleted(const QList<ParsedDesktopEntryData>& s
 		auto excludedIds = QSet<QString>();
 		auto seenFallbackDirectiveIds = QSet<QString>();
 
-		// Collect config dirs in priority order.
-		auto configDirs = QStringList();
-		{
-			auto configHome = qEnvironmentVariable("XDG_CONFIG_HOME");
-			if (configHome.isEmpty() && qEnvironmentVariableIsSet("HOME"))
-				configHome = qEnvironmentVariable("HOME") + "/.config";
-			if (!configHome.isEmpty()) configDirs.append(configHome);
-
-			auto configDirsStr = qEnvironmentVariable("XDG_CONFIG_DIRS");
-			if (configDirsStr.isEmpty()) configDirsStr = "/etc/xdg";
-			for (const auto& dir: configDirsStr.split(':', Qt::SkipEmptyParts)) configDirs.append(dir);
-
-			auto dataDirs = qEnvironmentVariable("XDG_DATA_DIRS");
-			if (dataDirs.isEmpty()) dataDirs = "/usr/local/share:/usr/share";
-			for (const auto& dir: dataDirs.split(':', Qt::SkipEmptyParts))
-				configDirs.append(dir + "/xdg-terminal-exec");
-		}
-
 		auto parseConfigFile = [&](const QString& path) {
 			auto isValidConfigEntryId = [](const QString& id) {
 				if (!id.endsWith(".desktop") || id == ".desktop") return false;
@@ -817,11 +832,7 @@ void DesktopEntryManager::onScanCompleted(const QList<ParsedDesktopEntryData>& s
 			}
 		};
 
-		for (const auto& dir: configDirs) {
-			for (const auto& name: desktopNames)
-				parseConfigFile(dir + "/" + name.toLower() + "-xdg-terminals.list");
-			parseConfigFile(dir + "/xdg-terminals.list");
-		}
+		for (const auto& path: DesktopEntryManager::terminalConfigPaths()) parseConfigFile(path);
 
 		// Expand escape sequences in X-TerminalArg* values (\s \n \t \r \\).
 		auto expandEscapes = [](const QString& value) {

--- a/src/core/desktopentry.cpp
+++ b/src/core/desktopentry.cpp
@@ -15,6 +15,7 @@
 #include <qpair.h>
 #include <qproperty.h>
 #include <qscopeguard.h>
+#include <qstandardpaths.h>
 #include <qtenvironmentvariables.h>
 #include <qthreadpool.h>
 #include <qtmetamacros.h>
@@ -128,8 +129,18 @@ ParsedDesktopEntryData DesktopEntry::parseText(const QString& id, const QString&
 				else if (key == "Exec") {
 					data.execString = value;
 					data.command = DesktopEntry::parseExecString(value);
-				} else if (key == "Path") data.workingDirectory = value;
-				else if (key == "Terminal") data.terminal = value == "true";
+				} else if (key == "TryExec") data.tryExec = value;
+				else if (key == "Path") data.workingDirectory = value;
+				else if (key == "Terminal") data.runInTerminal = value == "true";
+				else if (key == "X-TerminalArgExec" || key == "TerminalArgExec")
+					data.terminal.execArg = value;
+				else if (key == "X-TerminalArgAppId" || key == "TerminalArgAppId")
+					data.terminal.appIdArg = value;
+				else if (key == "X-TerminalArgTitle" || key == "TerminalArgTitle")
+					data.terminal.titleArg = value;
+				else if (key == "X-TerminalArgDir" || key == "TerminalArgDir") data.terminal.dirArg = value;
+				else if (key == "X-TerminalArgHold" || key == "TerminalArgHold")
+					data.terminal.holdArg = value;
 				else if (key == "Categories") data.categories = value.split(u';', Qt::SkipEmptyParts);
 				else if (key == "Keywords") data.keywords = value.split(u';', Qt::SkipEmptyParts);
 				else if (key == "Actions") actionOrder = value.split(u';', Qt::SkipEmptyParts);
@@ -218,10 +229,20 @@ void DesktopEntry::updateState(const ParsedDesktopEntryData& newState) {
 	this->bExecString = newState.execString;
 	this->bCommand = newState.command;
 	this->bWorkingDirectory = newState.workingDirectory;
-	this->bRunInTerminal = newState.terminal;
+	this->bRunInTerminal = newState.runInTerminal;
 	this->bCategories = newState.categories;
 	this->bKeywords = newState.keywords;
 	Qt::endPropertyUpdateGroup();
+
+	this->tryExec = newState.tryExec;
+	this->sourcePriority = newState.sourcePriority;
+	this->terminal = {
+	    .execArg = newState.terminal.execArg,
+	    .appIdArg = newState.terminal.appIdArg,
+	    .titleArg = newState.terminal.titleArg,
+	    .dirArg = newState.terminal.dirArg,
+	    .holdArg = newState.terminal.holdArg,
+	};
 
 	this->state = newState;
 	this->updateActions(newState.actions);
@@ -258,7 +279,15 @@ void DesktopEntry::updateActions(const QVector<DesktopActionData>& newActions) {
 }
 
 void DesktopEntry::execute() const {
-	DesktopEntry::doExec(this->bCommand.value(), this->bWorkingDirectory.value());
+	DesktopEntry::doExec(
+	    this->bCommand.value(),
+	    this->bWorkingDirectory.value(),
+	    {
+	        .enabled = this->bRunInTerminal.value(),
+	        .appId = this->bStartupClass.value().isEmpty() ? this->mId : this->bStartupClass.value(),
+	        .title = this->bName.value(),
+	    }
+	);
 }
 
 bool DesktopEntry::isValid() const { return !this->bName.value().isEmpty(); }
@@ -335,15 +364,87 @@ QVector<QString> DesktopEntry::parseExecString(const QString& execString) {
 	return arguments;
 }
 
-void DesktopEntry::doExec(const QList<QString>& execString, const QString& workingDirectory) {
+void DesktopEntry::doExec(
+    const QList<QString>& execString,
+    const QString& workingDirectory,
+    const DoExecTerminal& terminal
+) {
+	auto command = execString;
+
+	if (terminal.enabled) {
+		auto* manager = DesktopEntryManager::instance();
+		auto found = false;
+
+		for (const auto& term: manager->resolvedTerminals) {
+			if (!term.tryExec.isEmpty() && QStandardPaths::findExecutable(term.tryExec).isEmpty()) {
+				qCWarning(logDesktopEntry) << "Terminal" << term.command.first() << "TryExec"
+				                           << term.tryExec << "not found in PATH (skipping)";
+				continue;
+			}
+
+			if (term.command.isEmpty() || QStandardPaths::findExecutable(term.command.first()).isEmpty())
+			{
+				qCWarning(logDesktopEntry)
+				    << "Terminal executable" << (term.command.isEmpty() ? "(empty)" : term.command.first())
+				    << "not found in PATH (skipping)";
+				continue;
+			}
+
+			command = QList<QString>();
+			command.append(term.command);
+
+			auto appendTermArg = [&command](const QString& arg, const QString& value) {
+				if (arg.isEmpty() || value.isEmpty()) return;
+				if (arg.endsWith('=')) {
+					command.append(arg + value);
+				} else {
+					command.append(arg);
+					command.append(value);
+				}
+			};
+
+			appendTermArg(term.appIdArg, terminal.appId);
+			appendTermArg(term.titleArg, terminal.title);
+			appendTermArg(term.dirArg, workingDirectory);
+
+			// Do not append the exec argumnet (the "-e" in ghostty -e bash) if it is empty.
+			//
+			// If we don't add a check & the exec argument doesn't exist,
+			// arguments would look like ["termemulator", "", "hx", "a.cpp", "a.hpp"],
+			// which is not desired.
+			if (!term.execArg.isEmpty()) command.append(term.execArg);
+			command.append(
+			    execString
+			); // This is a special(ly stupid) overload in QList. Think of it as Rust's `Vec::extend`.
+
+			qCDebug(logDesktopEntry) << "Using terminal emulator:" << term.command.first();
+			found = true;
+			break;
+		}
+
+		if (!found) {
+			qCWarning(logDesktopEntry) << "No terminal emulator found; refusing to run without terminal.";
+			return;
+		}
+	}
+
 	qs::io::process::ProcessContext ctx;
-	ctx.setCommand(execString);
+	ctx.setCommand(command);
 	ctx.setWorkingDirectory(workingDirectory);
 	QuickshellGlobal::execDetached(ctx);
 }
 
 void DesktopAction::execute() const {
-	DesktopEntry::doExec(this->bCommand.value(), this->entry->bWorkingDirectory.value());
+	auto* e = this->entry;
+	DesktopEntry::doExec(
+	    this->bCommand.value(),
+	    e->bWorkingDirectory.value(),
+	    {
+	        .enabled = e->bRunInTerminal.value(),
+	        .appId = e->bStartupClass.value().isEmpty() ? e->mId : e->bStartupClass.value(),
+	        .title = e->bName.value(),
+	    }
+	);
 }
 
 DesktopEntryScanner::DesktopEntryScanner(DesktopEntryManager* manager): manager(manager) {
@@ -354,11 +455,14 @@ void DesktopEntryScanner::run() {
 	const auto& desktopPaths = DesktopEntryManager::desktopPaths();
 	auto scanResults = QList<ParsedDesktopEntryData>();
 
+	auto sourcePriority = desktopPaths.size();
 	for (const auto& path: desktopPaths | std::views::reverse) {
+		--sourcePriority; // Can't use std::views::enumerate, boo hoo.
+
 		auto file = QFileInfo(path);
 		if (!file.isDir()) continue;
 
-		this->scanDirectory(QDir(path), QString(), scanResults);
+		this->scanDirectory(QDir(path), QString(), scanResults, static_cast<int>(sourcePriority));
 	}
 
 	QMetaObject::invokeMethod(
@@ -372,14 +476,15 @@ void DesktopEntryScanner::run() {
 void DesktopEntryScanner::scanDirectory(
     const QDir& dir,
     const QString& idPrefix,
-    QList<ParsedDesktopEntryData>& entries
+    QList<ParsedDesktopEntryData>& entries,
+    int sourcePriority
 ) {
 	auto dirEntries = dir.entryInfoList(QDir::Dirs | QDir::Files | QDir::NoDotAndDotDot);
 
 	for (auto& entry: dirEntries) {
 		if (entry.isDir()) {
 			auto subdirPrefix = idPrefix.isEmpty() ? entry.fileName() : idPrefix + '-' + entry.fileName();
-			this->scanDirectory(QDir(entry.absoluteFilePath()), subdirPrefix, entries);
+			this->scanDirectory(QDir(entry.absoluteFilePath()), subdirPrefix, entries, sourcePriority);
 		} else if (entry.isFile()) {
 			auto path = entry.filePath();
 			if (!path.endsWith(".desktop")) {
@@ -398,6 +503,7 @@ void DesktopEntryScanner::scanDirectory(
 			auto content = QString::fromUtf8(file.readAll());
 
 			auto data = DesktopEntry::parseText(id, content);
+			data.sourcePriority = sourcePriority;
 			entries.append(std::move(data));
 		}
 	}
@@ -582,6 +688,231 @@ void DesktopEntryManager::onScanCompleted(const QList<ParsedDesktopEntryData>& s
 		if (!entry->bNoDisplay) newApplications.append(entry);
 
 	this->mApplications.diffUpdate(newApplications);
+
+	// Resolve terminal emulators via xdg-terminal-exec strict mode algorithm.
+	{
+		this->resolvedTerminals.clear();
+
+		struct ConfigEntry {
+			QString id;
+			QString action;
+		};
+		enum class ConfigLineType { Explicit, Exclude, Protect };
+
+		auto configEntries = QVector<ConfigEntry>();
+		auto seenExplicitIds = QSet<QString>();
+		auto excludedIds = QSet<QString>();
+		auto seenFallbackDirectiveIds = QSet<QString>();
+
+		// Collect config dirs in priority order.
+		auto configDirs = QStringList();
+		{
+			auto configHome = qEnvironmentVariable("XDG_CONFIG_HOME");
+			if (configHome.isEmpty() && qEnvironmentVariableIsSet("HOME"))
+				configHome = qEnvironmentVariable("HOME") + "/.config";
+			if (!configHome.isEmpty()) configDirs.append(configHome);
+
+			auto configDirsStr = qEnvironmentVariable("XDG_CONFIG_DIRS");
+			if (configDirsStr.isEmpty()) configDirsStr = "/etc/xdg";
+			for (const auto& dir: configDirsStr.split(':', Qt::SkipEmptyParts)) configDirs.append(dir);
+
+			auto dataDirs = qEnvironmentVariable("XDG_DATA_DIRS");
+			if (dataDirs.isEmpty()) dataDirs = "/usr/local/share:/usr/share";
+			for (const auto& dir: dataDirs.split(':', Qt::SkipEmptyParts))
+				configDirs.append(dir + "/xdg-terminal-exec");
+		}
+
+		auto parseConfigFile = [&](const QString& path) {
+			auto isValidConfigEntryId = [](const QString& id) {
+				if (!id.endsWith(".desktop") || id == ".desktop") return false;
+
+				return std::ranges::all_of(id, [](QChar c) {
+					auto u = c.unicode();
+					return (u >= 'a' && u <= 'z') || (u >= 'A' && u <= 'Z') || (u >= '0' && u <= '9')
+					    || u == '_' || u == '.' || u == '-';
+				});
+			};
+			auto isValidConfigActionId = [](const QString& id) {
+				return std::ranges::all_of(id, [](QChar c) {
+					auto u = c.unicode();
+					return (u >= 'a' && u <= 'z') || (u >= 'A' && u <= 'Z') || (u >= '0' && u <= '9')
+					    || u == '-';
+				});
+			};
+
+			auto file = QFile(path);
+			if (!file.open(QFile::ReadOnly | QFile::Text)) return;
+
+			qCDebug(logDesktopEntry) << "Reading terminal config:" << path;
+			auto content = QString::fromUtf8(file.readAll());
+
+			for (const auto& rawLine: content.split('\n', Qt::SkipEmptyParts)) {
+				auto line = rawLine.trimmed();
+				if (line.isEmpty() || line.startsWith('#') || line.startsWith('/')) continue;
+
+				auto type = ConfigLineType::Explicit;
+				auto target = line;
+
+				if (target.startsWith('-')) {
+					type = ConfigLineType::Exclude;
+					target = target.mid(1);
+				} else if (target.startsWith('+')) {
+					type = ConfigLineType::Protect;
+					target = target.mid(1);
+				}
+
+				auto desktopFileId = target;
+				auto actionId = QString();
+				auto colonIdx = target.indexOf(':');
+				if (colonIdx != -1) {
+					actionId = target.mid(colonIdx + 1);
+					desktopFileId = target.left(colonIdx);
+				}
+
+				if (!isValidConfigEntryId(desktopFileId) || !isValidConfigActionId(actionId)) {
+					qCWarning(logDesktopEntry) << "Discarding invalid terminal config entry:" << line;
+					continue;
+				}
+
+				auto entryId = desktopFileId.chopped(8);
+
+				if (type == ConfigLineType::Exclude || type == ConfigLineType::Protect) {
+					if (seenFallbackDirectiveIds.contains(entryId)) continue;
+					seenFallbackDirectiveIds.insert(entryId);
+					if (type == ConfigLineType::Exclude) excludedIds.insert(entryId);
+					continue;
+				}
+
+				if (seenExplicitIds.contains(entryId)) continue;
+				seenExplicitIds.insert(entryId);
+
+				configEntries.append({
+				    .id = entryId,
+				    .action = actionId,
+				});
+			}
+		};
+
+		for (const auto& dir: configDirs) {
+			for (const auto& name: desktopNames)
+				parseConfigFile(dir + "/" + name.toLower() + "-xdg-terminals.list");
+			parseConfigFile(dir + "/xdg-terminals.list");
+		}
+
+		// Expand escape sequences in X-TerminalArg* values (\s \n \t \r \\).
+		auto expandEscapes = [](const QString& value) {
+			QString result;
+			result.reserve(value.size());
+			auto escape = false;
+
+			for (auto c: value) {
+				if (escape) {
+					switch (c.unicode()) {
+					case 's': result += u' '; break;
+					case 'n': result += u'\n'; break;
+					case 't': result += u'\t'; break;
+					case 'r': result += u'\r'; break;
+					case '\\': result += u'\\'; break;
+					default:
+						qCWarning(logDesktopEntry).noquote()
+						    << "Illegal escape sequence in desktop entry terminal arg:" << value;
+						result += c;
+						break;
+					}
+					escape = false;
+				} else if (c == u'\\') {
+					escape = true;
+				} else {
+					result += c;
+				}
+			}
+
+			return result;
+		};
+
+		auto termWarn = [](const QString& id, const char* reason) {
+			qCWarning(logDesktopEntry) << "Terminal" << id << reason << "(skipping)";
+		};
+		auto termDebug = [](const QString& id, const char* reason) {
+			qCDebug(logDesktopEntry) << "Terminal" << id << reason << "(skipping)";
+		};
+
+		// Scan-time validation: structural checks only, no PATH lookups.
+		auto isValidTerminal = [](const DesktopEntry* entry, auto&& log) -> bool {
+			if (!entry->bCategories.value().contains("TerminalEmulator")) {
+				log(entry->mId, "missing TerminalEmulator category");
+				return false;
+			}
+			if (entry->bCommand.value().isEmpty()) {
+				log(entry->mId, "has empty Exec command");
+				return false;
+			}
+			if (!entry->terminal.execArg.has_value()) {
+				log(entry->mId, "missing [X-]TerminalArgExec");
+				return false;
+			}
+			return true;
+		};
+
+		auto addResolved =
+		    [this, &expandEscapes](const DesktopEntry* entry, const QVector<QString>& command) {
+			    this->resolvedTerminals.append({
+			        .command = command,
+			        .tryExec = entry->tryExec,
+			        .execArg = expandEscapes(entry->terminal.execArg.value()),
+			        .appIdArg = expandEscapes(entry->terminal.appIdArg),
+			        .titleArg = expandEscapes(entry->terminal.titleArg),
+			        .dirArg = expandEscapes(entry->terminal.dirArg),
+			        .holdArg = expandEscapes(entry->terminal.holdArg),
+			    });
+		    };
+
+		// Explicit phase: config entries in priority order.
+		for (const auto& configEntry: configEntries) {
+			auto* dentry = this->desktopEntries.value(configEntry.id);
+			if (!dentry) {
+				qCWarning(logDesktopEntry)
+				    << "Terminal" << configEntry.id
+				    << "not found in desktop entries (instructed from xdg-terminals.list)";
+				continue;
+			}
+			if (!isValidTerminal(dentry, termWarn)) continue;
+
+			auto command = dentry->bCommand.value();
+			if (!configEntry.action.isEmpty()) {
+				auto actions = dentry->actions();
+				auto action = std::ranges::find(actions, configEntry.action, &DesktopAction::mId);
+				if (action == actions.end()) {
+					qCWarning(logDesktopEntry)
+					    << "Terminal entry" << configEntry.id << "no action named" << configEntry.action;
+					continue;
+				}
+				command = (*action)->bCommand.value();
+			}
+
+			addResolved(dentry, command);
+			qCDebug(logDesktopEntry) << "Terminal candidate (explicit):" << dentry->mId;
+		}
+
+		// Fallback phase: remaining TerminalEmulator entries. Preserve XDG data-dir
+		// priority, sort by ID only where the spec leaves order undefined.
+		auto fallbackEntries = this->desktopEntries.values();
+		std::ranges::sort(fallbackEntries, [](const DesktopEntry* a, const DesktopEntry* b) {
+			if (a->sourcePriority != b->sourcePriority) return a->sourcePriority < b->sourcePriority;
+			return a->mId < b->mId;
+		});
+		for (auto* entry: fallbackEntries) {
+			if (seenExplicitIds.contains(entry->mId)) continue;
+			if (!isValidTerminal(entry, termDebug)) continue;
+			if (excludedIds.contains(entry->mId)) continue;
+
+			addResolved(entry, entry->bCommand.value());
+			qCDebug(logDesktopEntry) << "Terminal candidate (fallback):" << entry->mId;
+		}
+
+		qCDebug(logDesktopEntry) << "Resolved" << this->resolvedTerminals.size()
+		                         << "terminal candidates";
+	}
 
 	emit this->applicationsChanged();
 

--- a/src/core/desktopentry.hpp
+++ b/src/core/desktopentry.hpp
@@ -306,6 +306,7 @@ public:
 	static DesktopEntryManager* instance();
 
 	static const QStringList& desktopPaths();
+	static const QStringList& terminalConfigPaths();
 
 signals:
 	void applicationsChanged();

--- a/src/core/desktopentry.hpp
+++ b/src/core/desktopentry.hpp
@@ -35,6 +35,8 @@ struct ParsedDesktopEntryData {
 	QString genericName;
 	QString startupClass;
 	bool noDisplay = false;
+	std::optional<QVector<QString>> onlyShowIn;
+	std::optional<QVector<QString>> notShowIn;
 	bool hidden = false;
 	QString comment;
 	QString icon;
@@ -172,6 +174,8 @@ signals:
 	void runInTerminalChanged();
 	void categoriesChanged();
 	void keywordsChanged();
+	void onlyShowInChanged();
+	void notShowInChanged();
 
 public:
 	QString mId;
@@ -181,6 +185,8 @@ public:
 	Q_OBJECT_BINDABLE_PROPERTY(DesktopEntry, QString, bGenericName, &DesktopEntry::genericNameChanged);
 	Q_OBJECT_BINDABLE_PROPERTY(DesktopEntry, QString, bStartupClass, &DesktopEntry::startupClassChanged);
 	Q_OBJECT_BINDABLE_PROPERTY(DesktopEntry, bool, bNoDisplay, &DesktopEntry::noDisplayChanged);
+	Q_OBJECT_BINDABLE_PROPERTY(DesktopEntry, std::optional<QVector<QString>>, bOnlyShowIn, &DesktopEntry::onlyShowInChanged);
+	Q_OBJECT_BINDABLE_PROPERTY(DesktopEntry, std::optional<QVector<QString>>, bNotShowIn, &DesktopEntry::notShowInChanged);
 	Q_OBJECT_BINDABLE_PROPERTY(DesktopEntry, QString, bComment, &DesktopEntry::commentChanged);
 	Q_OBJECT_BINDABLE_PROPERTY(DesktopEntry, QString, bIcon, &DesktopEntry::iconChanged);
 	Q_OBJECT_BINDABLE_PROPERTY(DesktopEntry, QString, bExecString, &DesktopEntry::execStringChanged);

--- a/src/core/desktopentry.hpp
+++ b/src/core/desktopentry.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <optional>
 #include <utility>
 
 #include <qcontainerfwd.h>
@@ -29,6 +30,7 @@ struct DesktopActionData {
 
 struct ParsedDesktopEntryData {
 	QString id;
+	int sourcePriority = 0;
 	QString name;
 	QString genericName;
 	QString startupClass;
@@ -39,7 +41,15 @@ struct ParsedDesktopEntryData {
 	QString execString;
 	QVector<QString> command;
 	QString workingDirectory;
-	bool terminal = false;
+	bool runInTerminal = false;
+	QString tryExec;
+	struct {
+		std::optional<QString> execArg;
+		QString appIdArg;
+		QString titleArg;
+		QString dirArg;
+		QString holdArg;
+	} terminal;
 	QVector<QString> categories;
 	QVector<QString> keywords;
 	QHash<QString, QString> entries;
@@ -94,9 +104,15 @@ public:
 	static ParsedDesktopEntryData parseText(const QString& id, const QString& text);
 	void updateState(const ParsedDesktopEntryData& newState);
 
-	/// Run the application. Currently ignores @@runInTerminal and field codes.
+	/// Run the application. Currently ignores field codes (%f, %u, %F, %U, etc encoded in @@command).
 	///
-	/// This is equivalent to calling @@Quickshell.Quickshell.execDetached() with @@command
+	/// When @@runInTerminal is true, a suitable terminal emulator resolved via
+	/// the [xdg-terminal-exec] strict mode algorithm is spawned, with @@command,
+	/// ID (@@startupClass, or if it is not set, @@id), @@name and @@workingDirectory
+	/// passed in as arguments.
+	///
+	/// When @@runInTerminal is false, this is equivalent to calling
+	/// @@Quickshell.Quickshell.execDetached() with @@command
 	/// and @@DesktopEntry.workingDirectory as shown below:
 	///
 	/// ```qml
@@ -105,6 +121,8 @@ public:
 	///   workingDirectory: desktopEntry.workingDirectory,
 	/// });
 	/// ```
+	///
+	/// [xdg-terminal-exec]: https://github.com/Vladimir-csp/xdg-terminal-exec
 	Q_INVOKABLE void execute() const;
 
 	[[nodiscard]] bool isValid() const;
@@ -127,9 +145,19 @@ public:
 	}
 	[[nodiscard]] QBindable<QVector<QString>> bindableKeywords() const { return &this->bKeywords; }
 
-	// currently ignores all field codes.
+	struct DoExecTerminal {
+		bool enabled;
+		QString appId;
+		QString title;
+	};
+
+	// currently ignores all field codes (%f, %u, %F, %U, etc).
 	static QVector<QString> parseExecString(const QString& execString);
-	static void doExec(const QList<QString>& execString, const QString& workingDirectory);
+	static void doExec(
+	    const QList<QString>& execString,
+	    const QString& workingDirectory,
+	    const DoExecTerminal& terminal = {}
+	);
 
 signals:
 	void nameChanged();
@@ -162,6 +190,17 @@ public:
 	Q_OBJECT_BINDABLE_PROPERTY(DesktopEntry, QVector<QString>, bCategories, &DesktopEntry::categoriesChanged);
 	Q_OBJECT_BINDABLE_PROPERTY(DesktopEntry, QVector<QString>, bKeywords, &DesktopEntry::keywordsChanged);
 	// clang-format on
+
+	// TODO: Expose as bindable.
+	QString tryExec;
+	int sourcePriority = 0;
+	struct {
+		std::optional<QString> execArg;
+		QString appIdArg;
+		QString titleArg;
+		QString dirArg;
+		QString holdArg;
+	} terminal;
 
 private:
 	void updateActions(const QVector<DesktopActionData>& newActions);
@@ -202,10 +241,7 @@ public:
 	    , entry(entry)
 	    , mId(std::move(id)) {}
 
-	/// Run the application. Currently ignores @@DesktopEntry.runInTerminal and field codes.
-	///
-	/// This is equivalent to calling @@Quickshell.Quickshell.execDetached() with @@command
-	/// and @@DesktopEntry.workingDirectory.
+	/// Run the action. See @@DesktopEntry.execute() for details on terminal handling.
 	Q_INVOKABLE void execute() const;
 
 	[[nodiscard]] QBindable<QString> bindableName() const { return &this->bName; }
@@ -232,6 +268,7 @@ private:
 	// clang-format on
 
 	friend class DesktopEntry;
+	friend class DesktopEntryManager;
 };
 
 class DesktopEntryManager;
@@ -242,7 +279,7 @@ public:
 
 	void run() override;
 	// clang-format off
-	void scanDirectory(const QDir& dir, const QString& idPrefix, QList<ParsedDesktopEntryData>& entries);
+	void scanDirectory(const QDir& dir, const QString& idPrefix, QList<ParsedDesktopEntryData>& entries, int sourcePriority);
 	// clang-format on
 
 private:
@@ -274,13 +311,25 @@ private slots:
 private:
 	explicit DesktopEntryManager();
 
+	struct ResolvedTerminal {
+		QVector<QString> command;
+		QString tryExec;
+		QString execArg;
+		QString appIdArg;
+		QString titleArg;
+		QString dirArg;
+		QString holdArg;
+	};
+
 	QHash<QString, DesktopEntry*> desktopEntries;
 	QHash<QString, DesktopEntry*> lowercaseDesktopEntries;
 	ObjectModel<DesktopEntry> mApplications {this};
+	QVector<ResolvedTerminal> resolvedTerminals;
 	DesktopEntryMonitor* monitor = nullptr;
 	bool scanInProgress = false;
 	bool scanQueued = false;
 
+	friend class DesktopEntry;
 	friend class DesktopEntryScanner;
 };
 

--- a/src/core/desktopentrymonitor.cpp
+++ b/src/core/desktopentrymonitor.cpp
@@ -31,7 +31,13 @@ DesktopEntryMonitor::DesktopEntryMonitor(QObject* parent): QObject(parent) {
 	    &this->watcher,
 	    &QFileSystemWatcher::directoryChanged,
 	    this,
-	    &DesktopEntryMonitor::onDirectoryChanged
+	    &DesktopEntryMonitor::onWatchedPathChanged
+	);
+	QObject::connect(
+	    &this->watcher,
+	    &QFileSystemWatcher::fileChanged,
+	    this,
+	    &DesktopEntryMonitor::onWatchedPathChanged
 	);
 	QObject::connect(
 	    &this->debounceTimer,
@@ -40,14 +46,17 @@ DesktopEntryMonitor::DesktopEntryMonitor(QObject* parent): QObject(parent) {
 	    &DesktopEntryMonitor::processChanges
 	);
 
-	this->startMonitoring();
+	this->updateWatchedPaths();
 }
 
-void DesktopEntryMonitor::startMonitoring() {
+void DesktopEntryMonitor::updateWatchedPaths() {
 	for (const auto& path: DesktopEntryManager::desktopPaths()) {
-		if (!QDir(path).exists()) continue;
 		addPathAndParents(this->watcher, path);
 		this->scanAndWatch(path);
+	}
+
+	for (const auto& path: DesktopEntryManager::terminalConfigPaths()) {
+		addPathAndParents(this->watcher, path);
 	}
 }
 
@@ -61,8 +70,11 @@ void DesktopEntryMonitor::scanAndWatch(const QString& dirPath) {
 	for (const auto& subdir: subdirs) this->watcher.addPath(subdir.absoluteFilePath());
 }
 
-void DesktopEntryMonitor::onDirectoryChanged(const QString& /*path*/) {
+void DesktopEntryMonitor::onWatchedPathChanged(const QString& /*path*/) {
 	this->debounceTimer.start();
 }
 
-void DesktopEntryMonitor::processChanges() { emit this->desktopEntriesChanged(); }
+void DesktopEntryMonitor::processChanges() {
+	this->updateWatchedPaths();
+	emit this->desktopEntriesChanged();
+}

--- a/src/core/desktopentrymonitor.hpp
+++ b/src/core/desktopentrymonitor.hpp
@@ -20,11 +20,11 @@ signals:
 	void desktopEntriesChanged();
 
 private slots:
-	void onDirectoryChanged(const QString& path);
+	void onWatchedPathChanged(const QString& path);
 	void processChanges();
 
 private:
-	void startMonitoring();
+	void updateWatchedPaths();
 	void scanAndWatch(const QString& dirPath);
 
 	QFileSystemWatcher watcher;

--- a/src/launch/launch.cpp
+++ b/src/launch/launch.cpp
@@ -196,13 +196,10 @@ int launch(const LaunchArgs& args, char** argv, QCoreApplication* coreApplicatio
 	// This seems to be controlled by the QPA and qt6ct does not provide it.
 	{
 		QList<QString> dataPaths;
-
-		if (qEnvironmentVariableIsSet("XDG_DATA_DIRS")) {
-			auto var = qEnvironmentVariable("XDG_DATA_DIRS");
-			dataPaths = var.split(u':', Qt::SkipEmptyParts);
-		} else {
-			dataPaths.push_back("/usr/local/share");
-			dataPaths.push_back("/usr/share");
+		{
+			auto dataDirs = qEnvironmentVariable("XDG_DATA_DIRS");
+			if (dataDirs.isEmpty()) dataDirs = "/usr/local/share:/usr/share";
+			dataPaths = dataDirs.split(u':', Qt::SkipEmptyParts);
 		}
 
 		auto fallbackPaths = QIcon::fallbackSearchPaths();


### PR DESCRIPTION
Adds support for executing `Terminal=true` desktop entries with `DesktopEntry.execute()` by reading `xdg-terminals.list` and scanning for terminals with TerminalEmulator in their categories and valid [X-]TerminalArg* attributes set.

Also adds support for `OnlyShowIn`, `NotShowIn`, `TryExec` to match `xdg-terminal-exec`'s total behaviour.

Another thing fixed in this PR is the usage of XDG_DATA_DIR, the spec says that an empty value should still default to the usr paths. This makes the code respect that.