### PR TITLE
i3/workspace: Use name instead of id for activate

### DIFF
--- a/changelog/next.md
+++ b/changelog/next.md
@@ -61,6 +61,7 @@ set shell id.
 - Fixed partial socket reads in greetd and hyprland on slow machines.
 - Worked around Qt bug causing crashes when plugging and unplugging monitors.
 - Fixed HyprlandFocusGrab crashing if windows were destroyed after being passed to it.
+- Fixed `I3Workspace.activate()` sending invalid commands to i3/sway for named or special workspaces.
 
 ## Packaging Changes
 

--- a/src/x11/i3/ipc/workspace.cpp
+++ b/src/x11/i3/ipc/workspace.cpp
@@ -55,7 +55,7 @@ void I3Workspace::updateFromObject(const QVariantMap& obj) {
 }
 
 void I3Workspace::activate() {
-	this->ipc->dispatch(QString("workspace number %1").arg(this->bNumber.value()));
+	this->ipc->dispatch(QString("workspace %1").arg(this->bName.value()));
 }
 
 } // namespace qs::i3::ipc

--- a/src/x11/i3/ipc/workspace.hpp
+++ b/src/x11/i3/ipc/workspace.hpp
@@ -47,7 +47,7 @@ public:
 	///
 	/// > [!NOTE] This is equivalent to running
 	/// > ```qml
-	/// > I3.dispatch(`workspace number ${workspace.number}`);
+	/// > I3.dispatch(`workspace ${workspace.name}`);
 	/// > ```
 	Q_INVOKABLE void activate();
 


### PR DESCRIPTION
Mirrors the change made for hyprland/workspace in f90bef2d994c88f075dbc2fcd81140e160351328 and does it for i3/sway.