### PR TITLE
(CMake) wayland: add missing wayland-client CFLAGS

### DIFF
--- a/src/wayland/CMakeLists.txt
+++ b/src/wayland/CMakeLists.txt
@@ -68,6 +68,7 @@ function (wl_proto target name dir)
 	target_include_directories(${target} INTERFACE ${PROTO_BUILD_PATH})
 	target_link_libraries(${target} wl-proto-${name}-wl Qt6::WaylandClient Qt6::WaylandClientPrivate)
 	qs_pch(${target} SET wayland-protocol)
+	target_compile_options(wl-proto-${name}-wl PRIVATE ${wayland_CFLAGS})
 endfunction()
 
 # -----


### PR DESCRIPTION
Fixes #276.

This is ridiculous. Please consider using Meson instead of this glorified replacement for Microsoft Batch scripts. What is the point of a build system if you have to manually tell it how to build anything and it STILL gets it wrong half the time?