### PR TITLE
launch: add ability to override AppId via pragma or QS_APP_ID

### DIFF
--- a/changelog/next.md
+++ b/changelog/next.md
@@ -38,6 +38,7 @@ set shell id.
 - Added `QS_DISABLE_FILE_WATCHER` environment variable to disable file watching.
 - Added `QS_DISABLE_CRASH_HANDLER` environment variable to disable crash handling.
 - Added `QS_CRASHREPORT_URL` environment variable to allow overriding the crash reporter link.
+- Added `AppId` pragma and `QS_APP_ID` environment variable to allow overriding the desktop application ID.
 
 ## Bug Fixes
 

--- a/src/core/instanceinfo.cpp
+++ b/src/core/instanceinfo.cpp
@@ -3,14 +3,14 @@
 #include <qdatastream.h>
 
 QDataStream& operator<<(QDataStream& stream, const InstanceInfo& info) {
-	stream << info.instanceId << info.configPath << info.shellId << info.launchTime << info.pid
-	       << info.display;
+	stream << info.instanceId << info.configPath << info.shellId << info.appId << info.launchTime
+	       << info.pid << info.display;
 	return stream;
 }
 
 QDataStream& operator>>(QDataStream& stream, InstanceInfo& info) {
-	stream >> info.instanceId >> info.configPath >> info.shellId >> info.launchTime >> info.pid
-	    >> info.display;
+	stream >> info.instanceId >> info.configPath >> info.shellId >> info.appId >> info.launchTime
+	    >> info.pid >> info.display;
 	return stream;
 }
 

--- a/src/core/instanceinfo.hpp
+++ b/src/core/instanceinfo.hpp
@@ -9,6 +9,7 @@ struct InstanceInfo {
 	QString instanceId;
 	QString configPath;
 	QString shellId;
+	QString appId;
 	QDateTime launchTime;
 	pid_t pid = -1;
 	QString display;

--- a/src/crash/main.cpp
+++ b/src/crash/main.cpp
@@ -230,7 +230,9 @@ void qsCheckCrash(int argc, char** argv) {
 	);
 
 	auto app = QApplication(argc, argv);
-	QApplication::setDesktopFileName("org.quickshell");
+	auto desktopId =
+	    info.instance.appId.isEmpty() ? QStringLiteral("org.quickshell") : info.instance.appId;
+	QApplication::setDesktopFileName(desktopId);
 
 	auto crashDir = QsPaths::crashDir(info.instance.instanceId);
 

--- a/src/launch/launch.cpp
+++ b/src/launch/launch.cpp
@@ -76,6 +76,7 @@ int launch(const LaunchArgs& args, char** argv, QCoreApplication* coreApplicatio
 		bool useSystemStyle = false;
 		QString iconTheme = qEnvironmentVariable("QS_ICON_THEME");
 		QHash<QString, QString> envOverrides;
+		QString appId = qEnvironmentVariable("QS_APP_ID");
 		QString dataDir;
 		QString stateDir;
 		QString cacheDir;
@@ -104,6 +105,8 @@ int launch(const LaunchArgs& args, char** argv, QCoreApplication* coreApplicatio
 				auto var = envPragma.sliced(0, splitIdx).trimmed();
 				auto val = envPragma.sliced(splitIdx + 1).trimmed();
 				pragmas.envOverrides.insert(var, val);
+			} else if (pragma.startsWith("AppId ")) {
+				pragmas.appId = pragma.sliced(6).trimmed();
 			} else if (pragma.startsWith("ShellId ")) {
 				shellId = pragma.sliced(8).trimmed();
 			} else if (pragma.startsWith("DataDir ")) {
@@ -128,10 +131,13 @@ int launch(const LaunchArgs& args, char** argv, QCoreApplication* coreApplicatio
 	qInfo() << "Shell ID:" << shellId << "Path ID" << pathId;
 
 	auto launchTime = qs::Common::LAUNCH_TIME.toSecsSinceEpoch();
+	auto appId = pragmas.appId.isEmpty() ? QStringLiteral("org.quickshell") : pragmas.appId;
+
 	InstanceInfo::CURRENT = InstanceInfo {
 	    .instanceId = base36Encode(getpid()) + base36Encode(launchTime),
 	    .configPath = args.configPath,
 	    .shellId = shellId,
+	    .appId = appId,
 	    .launchTime = qs::Common::LAUNCH_TIME,
 	    .pid = getpid(),
 	    .display = getDisplayConnection(),
@@ -231,7 +237,7 @@ int launch(const LaunchArgs& args, char** argv, QCoreApplication* coreApplicatio
 		app = new QGuiApplication(qArgC, argv);
 	}
 
-	QGuiApplication::setDesktopFileName("org.quickshell");
+	QGuiApplication::setDesktopFileName(appId);
 
 	if (args.debugPort != -1) {
 		QQmlDebuggingEnabler::enableDebugging(true);


### PR DESCRIPTION
Since quickshell can be used to build standalone desktop apps, in a way - I think it makes sense to be able to override the hardcoded app ID so if I have multiple quickshell-built applets I can have desktop entries for each, icons, and window/layer rules that are targeted to the specific app IDs.

The only question is whether it should also be overridden in the crash reporter, but I assume it should be so I just made it apply universally.