### PR TITLE
wayland/lock: fix nullptr dereference

### DIFF
--- a/src/wayland/session_lock.cpp
+++ b/src/wayland/session_lock.cpp
@@ -274,7 +274,10 @@ void WlSessionLockSurface::show() {
 
 QQuickItem* WlSessionLockSurface::contentItem() const { return this->mContentItem; }
 
-bool WlSessionLockSurface::isVisible() const { return this->window->isVisible(); }
+bool WlSessionLockSurface::isVisible() const {
+	if (this->window == nullptr) return false;
+	return this->window->isVisible();
+}
 
 qint32 WlSessionLockSurface::width() const {
 	if (this->window == nullptr) return 0;


### PR DESCRIPTION
WlSessionLockSurface::isVisible() tries to access window.isVisible() even before
it is loaded, leading to segmentation fault.

Signed-off-by: Aditya Alok <dev.aditya.alok@gmail.com>
