### PR TITLE
fix: Audio devices not detected after pipewire changes

### DIFF
--- a/src/services/pipewire/peak.hpp
+++ b/src/services/pipewire/peak.hpp
@@ -8,15 +8,13 @@
 #include <qvector.h>
 
 #include "node.hpp"
+#include "qml.hpp"
 
 namespace qs::service::pipewire {
 
-class PwNodeIface;
 class PwPeakStream;
 
 } // namespace qs::service::pipewire
-
-Q_DECLARE_OPAQUE_POINTER(qs::service::pipewire::PwNodeIface*);
 
 namespace qs::service::pipewire {
 
@@ -24,7 +22,7 @@ namespace qs::service::pipewire {
 /// Tracks volume peaks for a node across all its channels.
 ///
 /// The peak monitor binds nodes similarly to @@PwObjectTracker when enabled.
-class PwNodePeakMonitor: public QObject {
+class QS_PIPEWIRE_EXPORT PwNodePeakMonitor: public QObject {
 	Q_OBJECT;
 	// clang-format off
 	/// The node to monitor. Must be an audio node.

--- a/src/services/pipewire/qml.hpp
+++ b/src/services/pipewire/qml.hpp
@@ -14,6 +14,12 @@
 #include "node.hpp"
 #include "registry.hpp"
 
+#if defined(__GNUC__) || defined(__clang__)
+#define QS_PIPEWIRE_EXPORT [[gnu::visibility("default")]]
+#else
+#define QS_PIPEWIRE_EXPORT
+#endif
+
 namespace qs::service::pipewire {
 
 class PwNodeIface;
@@ -30,7 +36,7 @@ public:
 	virtual void unref() = 0;
 };
 
-class PwObjectIface
+class QS_PIPEWIRE_EXPORT PwObjectIface
     : public QObject
     , public PwObjectRefIface {
 	Q_OBJECT;
@@ -53,7 +59,7 @@ private:
 };
 
 ///! Contains links to all pipewire objects.
-class Pipewire: public QObject {
+class QS_PIPEWIRE_EXPORT Pipewire: public QObject {
 	Q_OBJECT;
 	// clang-format off
 	/// All nodes present in pipewire.
@@ -172,7 +178,7 @@ private:
 };
 
 ///! Tracks non-monitor link connections to a given node.
-class PwNodeLinkTracker: public QObject {
+class QS_PIPEWIRE_EXPORT PwNodeLinkTracker: public QObject {
 	Q_OBJECT;
 	// clang-format off
 	/// The node to track connections to.
@@ -217,7 +223,7 @@ private:
 /// Extra properties of a @@PwNode if the node is an audio node.
 ///
 /// See @@PwNode.audio.
-class PwNodeAudioIface: public QObject {
+class QS_PIPEWIRE_EXPORT PwNodeAudioIface: public QObject {
 	Q_OBJECT;
 	// clang-format off
 	/// If the node is currently muted. Setting this property changes the mute state.
@@ -267,7 +273,7 @@ private:
 };
 
 ///! A node in the pipewire connection graph.
-class PwNodeIface: public PwObjectIface {
+class QS_PIPEWIRE_EXPORT PwNodeIface: public PwObjectIface {
 	Q_OBJECT;
 	/// The pipewire object id of the node.
 	///
@@ -347,7 +353,7 @@ private:
 ///! A connection between pipewire nodes.
 /// Note that there is one link per *channel* of a connection between nodes.
 /// You usually want @@PwLinkGroup.
-class PwLinkIface: public PwObjectIface {
+class QS_PIPEWIRE_EXPORT PwLinkIface: public PwObjectIface {
 	Q_OBJECT;
 	/// The pipewire object id of the link.
 	///
@@ -385,7 +391,7 @@ private:
 
 ///! A group of connections between pipewire nodes.
 /// A group of connections between pipewire nodes, one per source->target pair.
-class PwLinkGroupIface
+class QS_PIPEWIRE_EXPORT PwLinkGroupIface
     : public QObject
     , public PwObjectRefIface {
 	Q_OBJECT;
@@ -434,7 +440,7 @@ private:
 /// Properties that require their object be bound to use are clearly marked. You do not
 /// need to bind the object unless mentioned in the description of the property you
 /// want to use.
-class PwObjectTracker: public QObject {
+class QS_PIPEWIRE_EXPORT PwObjectTracker: public QObject {
 	Q_OBJECT;
 	/// The list of objects to bind. May contain nulls.
 	Q_PROPERTY(QList<QObject*> objects READ objects WRITE setObjects NOTIFY objectsChanged);


### PR DESCRIPTION
Fixes #558.

This PR works around a type metadata issue caused by building Quickshell with `mold` and LTO enabled, which prevents Quickshell from correctly detecting PipeWire audio devices.

The issue occurs because `mold` strips required Qt QML type information during the LTO process, leading to type mismatches at runtime.

This workaround adds `[[gnu::visibility("default")]]` to preserve the required type metadata so it is not discarded by the linker during LTO. With the metadata retained, PipeWire audio devices are detected correctly again.

This is a temporary workaround until the underlying `mold` LTO issue is resolved upstream.