### PR TITLE
pipewire: write route volumes without volume step

### DIFF
--- a/changelog/next.md
+++ b/changelog/next.md
@@ -1,4 +1,5 @@
 ## Bug Fixes
 
+- Fixed PipeWire route volume writes for devices without a reported volume step.
 - Fixed ScreencopyView not displaying when only lock surfaces are shown.
 - Fixed WlSessionLockSurface.visible crashing if accessed before backing surface creation.

--- a/src/services/pipewire/node.cpp
+++ b/src/services/pipewire/node.cpp
@@ -486,8 +486,8 @@ void PwNodeBoundAudio::setVolumes(const QVector<float>& volumes) {
 			                << "via device";
 			this->waitingVolumes = realVolumes;
 		} else {
+			auto significantChange = this->mServerVolumes.isEmpty() || this->volumeStep == -1;
 			if (this->volumeStep != -1) {
-				auto significantChange = this->mServerVolumes.isEmpty();
 				for (auto i = 0; i < this->mServerVolumes.length(); i++) {
 					auto serverVolume = this->mServerVolumes.value(i);
 					auto targetVolume = realVolumes.value(i);
@@ -496,25 +496,25 @@ void PwNodeBoundAudio::setVolumes(const QVector<float>& volumes) {
 						break;
 					}
 				}
+			}
 
-				if (significantChange) {
-					qCInfo(logNode) << "Changing volumes of" << this->node << "to" << realVolumes
-					                << "via device";
-					if (!this->node->device->setVolumes(this->node->routeDevice, realVolumes)) {
-						return;
-					}
-
-					this->mDeviceVolumes = realVolumes;
-					this->node->device->waitForDevice();
-				} else {
-					// Insignificant changes won't cause an info event on the device, leaving qs hung in the
-					// "waiting for acknowledgement" state forever.
-					qCInfo(logNode).nospace()
-					    << "Ignoring volume change for " << this->node << " to " << realVolumes << " from "
-					    << this->mServerVolumes
-					    << " as it is a device node and the change is too small (min step: "
-					    << this->volumeStep << ").";
+			if (significantChange) {
+				qCInfo(logNode) << "Changing volumes of" << this->node << "to" << realVolumes
+				                << "via device";
+				if (!this->node->device->setVolumes(this->node->routeDevice, realVolumes)) {
+					return;
 				}
+
+				this->mDeviceVolumes = realVolumes;
+				this->node->device->waitForDevice();
+			} else {
+				// Insignificant changes won't cause an info event on the device, leaving qs hung in the
+				// "waiting for acknowledgement" state forever.
+				qCInfo(logNode).nospace()
+				    << "Ignoring volume change for " << this->node << " to " << realVolumes << " from "
+				    << this->mServerVolumes
+				    << " as it is a device node and the change is too small (min step: " << this->volumeStep
+				    << ").";
 			}
 		}
 	} else {


### PR DESCRIPTION
## Summary

Fix PipeWire route volume writes for devices that do not report `SPA_PROP_volumeStep`.

On these devices, `volumeStep` is parsed as `-1`. The previous logic only called `PwDevice::setVolumes(...)` from inside the `volumeStep != -1` branch, so route-backed sink volume writes updated Quickshell's local `mVolumes` state but did not write the new volume to PipeWire.

This keeps the existing minimum-step filtering when a device reports `volumeStep`, and treats a missing step value as "no step threshold", allowing the route volume write to proceed.

Fixes #807

## Testing

- `just configure debug -DNO_PCH=ON -DBUILD_TESTING=ON`
- `just build`
- `git diff --check`
- Tested locally against a Bluetooth sink (`bluez_output.6C_5A_B5_EB_5E_8D.1`) by writing `Pipewire.defaultAudioSink.audio.volumes = [0.24, 0.24]` from QML and verifying `wpctl get-volume @DEFAULT_AUDIO_SINK@` changed to `Volume: 0.24`.

`just lint-changed` was not run because this local checkout does not have the required `TIDYFOX` environment variable configured.
