### PR TITLE
i3/ipc: Use workspace id to handle rename event

### DIFF
--- a/src/x11/i3/ipc/controller.cpp
+++ b/src/x11/i3/ipc/controller.cpp
@@ -291,7 +291,19 @@ void I3IpcController::handleWorkspaceEvent(I3IpcEvent* event) {
 		} else {
 			qCInfo(logI3Ipc) << "Workspace" << name << "has already been deleted";
 		}
-	} else if (change == "move" || change == "rename" || change == "urgent") {
+	} else if (change == "rename") {
+		auto id = event->mData["current"]["id"].toInt(-1);
+
+		auto* workspace = this->findWorkspaceByID(id);
+
+		if (workspace != nullptr) {
+			auto data = event->mData["current"].toObject().toVariantMap();
+
+			workspace->updateFromObject(data);
+		} else {
+			qCWarning(logI3Ipc) << "Workspace with id" << id << "doesn't exist";
+		}
+	} else if (change == "move" || change == "urgent") {
 		auto name = event->mData["current"]["name"].toString();
 
 		auto* workspace = this->findWorkspaceByName(name);


### PR DESCRIPTION
This fixes an issue where i3 rename events aren't being handled.

When a rename event comes in, the value of data.current.name is the NEW name value. When we search quickshell's internal workspace state, we can't find the workspace since quickshell still has the old name. This updates the rename event handler to find the workspace by id instead.

I've tested under sway ~and i3.~ EDIT: this fixes the issue in sway, but since i3 uses the value of point address for workspace ids, would need to update to use 64 bit ints everywhere as a separate fix

~Side note: I don't really know C or C++, but afiact it looks like i3 is using pointer addresses for workspace ids (see code below) however it looks like quickshell stores them as `qint32`. They were definitely coming out as 64 bit ints on my system. I had to use `toInteger` (which returns a qint64) instead of the `toInt` that is used elsewhere. I'm not sure if there are other repercussions to this, but I thought you should know.~


```
    # src/ipc.c:363 in i3
    ystr("id");
    y(integer, (uintptr_t)con);
```