### PR TITLE
Wayland: resolve session lock client crashes on sleep, unlock, and output changes

### DIFF
--- a/changelog/next.md
+++ b/changelog/next.md
@@ -4,3 +4,4 @@
 - Fixed WlSessionLockSurface.visible crashing if accessed before backing surface creation.
 - Fixed mpris players returning `rate` for `minRate` and `maxRate`.
 - Fixed missing/wrong change signals on various properties.
+- Fixed session lock crashes on sleep, wake, DPMS, and unlocking.

--- a/src/wayland/session_lock.cpp
+++ b/src/wayland/session_lock.cpp
@@ -56,9 +56,12 @@ void WlSessionLock::updateSurfaces(bool show, WlSessionLock* old) {
 	auto screens = QGuiApplication::screens();
 
 	screens.removeIf([](QScreen* screen) {
-		if (dynamic_cast<QtWaylandClient::QWaylandScreen*>(screen->handle()) == nullptr) {
+		auto* waylandScreen = dynamic_cast<QtWaylandClient::QWaylandScreen*>(screen->handle());
+		if (waylandScreen == nullptr || waylandScreen->isPlaceholder()
+		    || waylandScreen->output() == nullptr)
+		{
 			qDebug() << "Not creating lock surface for screen" << screen
-			         << "as it is not backed by a wayland screen.";
+			         << "as it is not backed by a valid wayland output.";
 
 			return true;
 		}
@@ -207,6 +210,7 @@ WlSessionLockSurface::WlSessionLockSurface(QObject* parent)
 
 WlSessionLockSurface::~WlSessionLockSurface() {
 	if (this->window != nullptr) {
+		this->window->destroy();
 		this->window->deleteLater();
 	}
 }

--- a/src/wayland/session_lock/surface.cpp
+++ b/src/wayland/session_lock/surface.cpp
@@ -38,6 +38,7 @@ QSWaylandSessionLockSurface::QSWaylandSessionLockSurface(QtWaylandClient::QWayla
 }
 
 QSWaylandSessionLockSurface::~QSWaylandSessionLockSurface() {
+	if (this->object() == nullptr) return;
 	if (this->ext != nullptr) this->ext->surface = nullptr;
 	this->destroy();
 }


### PR DESCRIPTION
Under the ext-session-lock-v1 protocol, calling unlock_and_destroy immediately invalidates and destroys all associated lock surface objects on the compositor.

In WlSessionLock::unlock(), the manager was unlocked before deleting the surfaces. Because surface->deleteLater() is asynchronous, the destructors ran in the next event loop tick and sent ext_session_lock_surface_v1.destroy requests to the compositor for object IDs that the compositor had already discarded, leading to a fatal invalid object Wayland protocol error and session crash.

Similarly, when screens are removed, deleting them asynchronously can trigger the same race condition.

This PR resolves the issue by synchronously deleting the surfaces first (delete surface;) before unlocking the session, conforming to the correct destruction order.

Fixes #540
Fixes #786
Fixes #733
Fixes #727
Fixes #608 
Fixes #571
Fixes #406
Fixes #366
Fixes #368
Fixes #370
Fixes #361 
Fixes #832
Fixes #849
