### PR TITLE
core/window: render a frame when re-enabling updatesEnabled

### DIFF
--- a/changelog/next.md
+++ b/changelog/next.md
@@ -5,3 +5,4 @@
 - Fixed mpris players returning `rate` for `minRate` and `maxRate`.
 - Fixed missing/wrong change signals on various properties.
 - Fixed session lock crashes on sleep, wake, DPMS, and unlocking.
+- QsWindow.updatesEnabled makes sure windows are redrawn when set to true.

--- a/src/window/proxywindow.cpp
+++ b/src/window/proxywindow.cpp
@@ -495,6 +495,10 @@ void ProxyWindowBase::setUpdatesEnabled(bool updatesEnabled) {
 
 	if (this->window != nullptr) {
 		QQuickWindowPrivate::get(this->window)->updatesEnabled = updatesEnabled;
+
+		// The render loop discards expose and update requests while updates are disabled,
+		// which can leave the surface without a valid buffer. Render a frame to recover.
+		if (updatesEnabled) this->window->update();
 	}
 
 	emit this->updatesEnabledChanged();

--- a/src/window/windowinterface.hpp
+++ b/src/window/windowinterface.hpp
@@ -148,6 +148,9 @@ class WindowInterface: public Reloadable {
 	/// When set to false, the window will not re-render in response to animations
 	/// or other visual updates from other windows. This is useful for static windows
 	/// such as wallpapers that do not need to update frequently, saving GPU cycles.
+	///
+	/// When set back to true, a new frame is rendered, including any changes made
+	/// while updates were disabled.
 	Q_PROPERTY(bool updatesEnabled READ updatesEnabled WRITE setUpdatesEnabled NOTIFY updatesEnabledChanged);
 	Q_PROPERTY(QQmlListProperty<QObject> data READ data);
 	// clang-format on


### PR DESCRIPTION
Forces a frame to be drawn when updatesEnabled is set from false -> true. Ensures that the expected scene is drawn when flipping the flag back to true. QT does not do it internally when setting the private flag to true.