### PR TITLE
services/polkit: register agent using XDG_SESSION_ID when available

### DIFF
--- a/changelog/next.md
+++ b/changelog/next.md
@@ -6,3 +6,4 @@
 - Fixed missing/wrong change signals on various properties.
 - Fixed session lock crashes on sleep, wake, DPMS, and unlocking.
 - QsWindow.updatesEnabled makes sure windows are redrawn when set to true.
+- Fixed the polkit agent failing to register when running outside a session cgroup, such as a systemd user service, by resolving the session from XDG_SESSION_ID.

--- a/src/services/polkit/listener.cpp
+++ b/src/services/polkit/listener.cpp
@@ -11,8 +11,11 @@
 #include <polkit/polkit.h>
 #include <polkit/polkittypes.h>
 #include <polkitagent/polkitagent.h>
+#include <qbytearray.h>
 #include <qlogging.h>
 #include <qloggingcategory.h>
+#include <qstring.h>
+#include <qtenvironmentvariables.h>
 #include <unistd.h>
 
 #include "../../core/logcat.hpp"
@@ -91,6 +94,34 @@ void qs_polkit_agent_register(QsPolkitAgent* agent, const char* path) {
 		qCWarning(logPolkitListener) << "cannot register listener without a path set.";
 		agent->cb->registerComplete(false);
 		return;
+	}
+
+	const auto sessionId = qEnvironmentVariable("XDG_SESSION_ID");
+	if (!sessionId.isEmpty()) {
+		const auto sessionIdUtf8 = sessionId.toUtf8();
+		auto* subject = polkit_unix_session_new(sessionIdUtf8.constData());
+		if (subject != nullptr) {
+			GError* error = nullptr;
+			agent->registration_handle = polkit_agent_listener_register(
+			    POLKIT_AGENT_LISTENER(agent),
+			    POLKIT_AGENT_REGISTER_FLAGS_NONE,
+			    subject,
+			    path,
+			    nullptr,
+			    &error
+			);
+			g_object_unref(subject);
+
+			if (error != nullptr) {
+				qCWarning(logPolkitListener) << "failed to register listener:" << error->message;
+				g_clear_error(&error);
+				agent->cb->registerComplete(false);
+				return;
+			}
+
+			agent->cb->registerComplete(true);
+			return;
+		}
 	}
 
 	auto* data = new RegisterCbData {.agent = GObjectRef(agent), .path = path};


### PR DESCRIPTION
qs_polkit_agent_register builds the agent subject with polkit_unix_session_new_for_process(getpid()), which resolves the logind session from the calling process's cgroup. When Quickshell runs outside a session-scope cgroup -- for example as a systemd user service -- there is no such session, subject creation fails, and the listener never registers ("failed to create subject for listener: No session for pid"). With no agent registered, polkit falls back to a text agent and authentication does not work for that session.
  
This prefers the session id from XDG_SESSION_ID and registers the listener for it, falling back to the existing pid-based path when the variable is unset. When the cgroup lookup fails, polkitd resolves the caller's session through sd_uid_get_display, so registration is accepted as long as XDG_SESSION_ID is the user's display session. This is the same approach hyprpolkitagent uses.

Tested on a session where the compositor and agent run as systemd user services: before, the agent failed to register and polkit fell back to the text agent; after, it registers and both GUI and pkexec authentication work.