### PR TITLE
notifications: fixed chrome web push notifications

### DIFF
--- a/src/launch/main.cpp
+++ b/src/launch/main.cpp
@@ -111,6 +111,7 @@ void exitDaemon(int code) {
 
 int main(int argc, char** argv) {
 	QCoreApplication::setApplicationName("quickshell");
+	QCoreApplication::setApplicationVersion(QS_VERSION);
 
 #if CRASH_HANDLER
 	qsCheckCrash(argc, argv);


### PR DESCRIPTION
## Problem

The freedesktop notifications `GetServerInformation` method returns an empty version string:

```
$ gdbus call --session \
    --dest org.freedesktop.Notifications \
    --object-path /org/freedesktop/Notifications \
    --method org.freedesktop.Notifications.GetServerInformation
('quickshell', 'quickshell', '', '1.2')
```

The third field (the server version) is empty. `NotificationServer::GetServerInformation` sources it from `QCoreApplication::applicationVersion()`, but `main()` only ever calls `setApplicationName("quickshell")` and never sets the application version, so `applicationVersion()` returns an empty string.

This isn't purely cosmetic: some clients treat a notification server with missing/empty server information as incomplete or non-conformant. For example, Chrome checks the server info when deciding whether to route native notifications through the freedesktop server, and an empty version can cause it to reject quickshell as a usable notification target. This results in Chrome creating it's own windows as a fallback mechanism for notifications.

## Fix

Set the application version from the already-available `QS_VERSION` macro in `main()`, right after the application name is set. `build.hpp` (which defines `QS_VERSION`) is already included by `main.cpp`, so this is self-contained.

```cpp
QCoreApplication::setApplicationName("quickshell");
QCoreApplication::setApplicationVersion(QS_VERSION);
```

After the change, `GetServerInformation` returns the real version:

```
('quickshell', 'quickshell', '0.3.0', '1.2')
```

## Testing

Verified `GetServerInformation` over D-Bus now reports the version string instead of an empty field and Chrome notifications working.

## Notes

I used plain `QS_VERSION` rather than the richer `QS_VERSION " (revision " GIT_REVISION ...)` format from `debuginfo.cpp`, to keep the D-Bus version field to a clean semver value — happy to switch to the fuller format if you'd prefer consistency with the debug output.