### PR TITLE
wayland/background-effect: attach effect surface when manager global appears late

### DIFF
--- a/changelog/next.md
+++ b/changelog/next.md
@@ -12,3 +12,4 @@
 - Fixed unhandled notifications sending `NotificationClosed` out of order.
 - Fixed `qs kill` not waiting for the process to exit.
 - Fixed IPC calls from children of a crashed and relaunched process crashing.
+- Fixed BackgroundEffect never applying if the compositor announces ext-background-effect-v1 after surface creation.

--- a/src/wayland/background_effect/manager.cpp
+++ b/src/wayland/background_effect/manager.cpp
@@ -32,7 +32,7 @@ void BackgroundEffectManager::ext_background_effect_manager_v1_capabilities(uint
 
 BackgroundEffectManager* BackgroundEffectManager::instance() {
 	static auto* instance = new BackgroundEffectManager(); // NOLINT
-	return instance->isInitialized() ? instance : nullptr;
+	return instance;
 }
 
 } // namespace qs::wayland::background_effect::impl

--- a/src/wayland/background_effect/qml.cpp
+++ b/src/wayland/background_effect/qml.cpp
@@ -192,11 +192,39 @@ void BackgroundEffect::onWaylandWindowDestroyed() { this->mWaylandWindow = nullp
 void BackgroundEffect::onWaylandSurfaceCreated() {
 	auto* manager = impl::BackgroundEffectManager::instance();
 
-	if (!manager) {
-		qWarning() << "Cannot enable background effect as ext-background-effect-v1 is not supported "
-		              "by the current compositor.";
+	if (!manager->isActive()) {
+		qWarning() << "Cannot enable background effect as ext-background-effect-v1 is not currently "
+		              "supported by the compositor. The effect will be enabled if the protocol "
+		              "becomes available.";
+
+		// The manager global may be announced at any point, including after surfaces
+		// that want an effect are created.
+		QObject::connect(
+		    manager,
+		    &impl::BackgroundEffectManager::activeChanged,
+		    this,
+		    &BackgroundEffect::onManagerActiveChanged
+		);
+
 		return;
 	}
+
+	this->attachEffectSurface();
+}
+
+void BackgroundEffect::onManagerActiveChanged() {
+	auto* manager = impl::BackgroundEffectManager::instance();
+	if (!manager->isActive()) return;
+
+	QObject::disconnect(manager, nullptr, this, nullptr);
+
+	if (this->proxyWindow && this->mWaylandWindow && this->mWaylandWindow->surface()) {
+		this->attachEffectSurface();
+	}
+}
+
+void BackgroundEffect::attachEffectSurface() {
+	auto* manager = impl::BackgroundEffectManager::instance();
 
 	// Steal protocol surface from previous BackgroundEffect to avoid duplicate-attachment on reload.
 	auto v = this->mWaylandWindow->property("qs_background_effect");
@@ -222,6 +250,8 @@ void BackgroundEffect::onWaylandSurfaceCreated() {
 }
 
 void BackgroundEffect::onWaylandSurfaceDestroyed() {
+	QObject::disconnect(impl::BackgroundEffectManager::instance(), nullptr, this, nullptr);
+
 	this->surface = nullptr;
 	this->pendingBlurRegion = false;
 

--- a/src/wayland/background_effect/qml.hpp
+++ b/src/wayland/background_effect/qml.hpp
@@ -62,12 +62,15 @@ private slots:
 	void onWaylandWindowDestroyed();
 	void onWaylandSurfaceCreated();
 	void onWaylandSurfaceDestroyed();
+	void onManagerActiveChanged();
 	void onProxyWindowDestroyed();
 	void onBlurRegionDestroyed();
 	void onWindowPolished();
 	void updateBlurRegion();
 
 private:
+	void attachEffectSurface();
+
 	ProxyWindowBase* proxyWindow = nullptr;
 	QWindow* mWindow = nullptr;
 	QtWaylandClient::QWaylandWindow* mWaylandWindow = nullptr;


### PR DESCRIPTION
If the compositor announces ext_background_effect_manager_v1 after a surface is created, ext-background-effect will not apply to the surface. I'm not sure if this is a 

With niri at least, this happens at compositor startup in some cases (https://github.com/AvengeMedia/DankMaterialShell/issues/2856), I'm not sure if this is a bug on niri's side as I haven't looked at that side much but in either case it makes sense to react to it if the protocol becomes available lazily.

This adds listener to activeChanged to attach the effect to the surface when it becomes active.