### PR TITLE
networking: add ability to manually add wifi networks

### DIFF
--- a/src/network/nm/settings.cpp
+++ b/src/network/nm/settings.cpp
@@ -162,28 +162,9 @@ QVariantMap NMSettings::read() {
 }
 
 void NMSettings::write(const QVariantMap& settings) {
-	NMSettingsMap changedSettings;
 	NMSettingsMap removedSettings;
 	QStringList failedSettings;
-
-	for (auto it = settings.constBegin(); it != settings.constEnd(); ++it) {
-		if (!it.value().canConvert<QVariantMap>()) continue;
-
-		auto group = it.value().toMap();
-		QVariantMap toChange;
-		QVariantMap toRemove;
-		for (auto jt = group.constBegin(); jt != group.constEnd(); ++jt) {
-			if (jt.value().isNull()) {
-				toRemove.insert(jt.key(), QVariant());
-			} else {
-				auto converted = settingTypeFromQml(it.key(), jt.key(), jt.value());
-				if (!converted.isValid()) failedSettings.append(it.key() + "." + jt.key());
-				else toChange.insert(jt.key(), converted);
-			}
-		}
-		if (!toChange.isEmpty()) changedSettings.insert(it.key(), toChange);
-		if (!toRemove.isEmpty()) removedSettings.insert(it.key(), toRemove);
-	}
+	const auto changedSettings = settingsMapFromQml(settings, removedSettings, failedSettings);
 
 	if (!failedSettings.isEmpty()) {
 		qCWarning(logNMSettings) << "A write to" << this

--- a/src/network/nm/utils.cpp
+++ b/src/network/nm/utils.cpp
@@ -490,6 +490,74 @@ NMSettingsMap settingsMapFromQml(
 	return changedSettings;
 }
 
+namespace {
+
+// Transform a cert path into the required format for nm
+QByteArray eapCertReference(const QString& value) {
+	if (value.startsWith("file://") || value.startsWith("pkcs11:")) return value.toUtf8();
+	if (value.startsWith('/')) {
+		QByteArray ref = "file://" + value.toUtf8();
+		ref.append('\0');
+		return ref;
+	}
+	return value.toUtf8();
+}
+
+// Builds an 802-1x settings group from EAP credentials for enterprise networks
+QVariantMap eapSettings(const QVariantMap& credentials, QStringList& errors) {
+	QVariantMap eap;
+
+	const auto method = credentials.value("eap").toString().toLower();
+	if (method.isEmpty()) {
+		errors.append("credentials.eap is required for an enterprise network");
+		return eap;
+	}
+	if (method != "peap" && method != "ttls" && method != "tls") {
+		errors.append("credentials.eap must be one of peap, ttls, or tls");
+		return eap;
+	}
+	eap.insert("eap", QStringList {method});
+
+	const auto identity = credentials.value("identity").toString();
+	if (identity.isEmpty())
+		errors.append("credentials.identity is required for an enterprise network");
+	else eap.insert("identity", identity);
+
+	const auto anonymousIdentity = credentials.value("anonymousIdentity").toString();
+	if (!anonymousIdentity.isEmpty()) eap.insert("anonymous-identity", anonymousIdentity);
+
+	const auto caCert = credentials.value("caCert").toString();
+	if (!caCert.isEmpty()) eap.insert("ca-cert", eapCertReference(caCert));
+
+	if (method == "tls") {
+		// EAP-TLS authenticates with a client certificate and private key.
+		const auto clientCert = credentials.value("clientCert").toString();
+		const auto privateKey = credentials.value("privateKey").toString();
+
+		if (clientCert.isEmpty()) errors.append("credentials.clientCert is required for EAP-TLS");
+		else eap.insert("client-cert", eapCertReference(clientCert));
+
+		if (privateKey.isEmpty()) errors.append("credentials.privateKey is required for EAP-TLS");
+		else eap.insert("private-key", eapCertReference(privateKey));
+
+		const auto privateKeyPassword = credentials.value("privateKeyPassword").toString();
+		if (!privateKeyPassword.isEmpty()) eap.insert("private-key-password", privateKeyPassword);
+	} else {
+		// PEAP / TTLS authenticate with an inner username + password.
+		const auto password = credentials.value("password").toString();
+		if (password.isEmpty())
+			errors.append("credentials.password is required for a PEAP/TTLS network");
+		else eap.insert("password", password);
+
+		const auto phase2Auth = credentials.value("phase2Auth").toString();
+		if (!phase2Auth.isEmpty()) eap.insert("phase2-auth", phase2Auth.toLower());
+	}
+
+	return eap;
+}
+
+} // namespace
+
 NMSettingsMap wifiConnectionSettings(
     const QString& ssid,
     WifiSecurityType::Enum security,
@@ -537,15 +605,33 @@ NMSettingsMap wifiConnectionSettings(
 		qmlSettings.insert("802-11-wireless-security", sec);
 		break;
 	}
-	case WifiSecurityType::Wpa2Eap:
 	case WifiSecurityType::WpaEap:
+	case WifiSecurityType::Wpa2Eap:
 	case WifiSecurityType::Wpa3SuiteB192:
-	case WifiSecurityType::DynamicWep:
-	case WifiSecurityType::Leap:
-		// TODO: build the 802-1x group (eap method, identity, password, phase2, certs) from
-		// credentials once enterprise support is implemented.
-		errors.append("enterprise (802.1x) networks are not yet implemented");
-		return {};
+	case WifiSecurityType::DynamicWep: {
+		const char* keyMgmt = security == WifiSecurityType::Wpa3SuiteB192 ? "wpa-eap-suite-b-192"
+		                    : security == WifiSecurityType::DynamicWep    ? "ieee8021x"
+		                                                                  : "wpa-eap";
+		qmlSettings.insert(
+		    "802-11-wireless-security",
+		    QVariantMap {{"key-mgmt", QString::fromLatin1(keyMgmt)}}
+		);
+		const auto eap = eapSettings(credentials, errors);
+		if (!eap.isEmpty()) qmlSettings.insert("802-1x", eap);
+		break;
+	}
+	case WifiSecurityType::Leap: {
+		// LEAP isn't 802-1x/EAP; the credentials live in the wireless-security group.
+		QVariantMap sec {{"key-mgmt", "ieee8021x"}, {"auth-alg", "leap"}};
+		const auto identity = credentials.value("identity").toString();
+		const auto password = credentials.value("password").toString();
+		if (identity.isEmpty()) errors.append("credentials.identity is required for a LEAP network");
+		else sec.insert("leap-username", identity);
+		if (password.isEmpty()) errors.append("credentials.password is required for a LEAP network");
+		else sec.insert("leap-password", password);
+		qmlSettings.insert("802-11-wireless-security", sec);
+		break;
+	}
 	}
 
 	if (!errors.isEmpty()) return {};

--- a/src/network/nm/utils.cpp
+++ b/src/network/nm/utils.cpp
@@ -461,6 +461,102 @@ QVariant settingTypeFromQml(const QString& group, const QString& key, const QVar
 	return value;
 }
 
+NMSettingsMap settingsMapFromQml(
+    const QVariantMap& settings,
+    NMSettingsMap& removedSettings,
+    QStringList& failedSettings
+) {
+	NMSettingsMap changedSettings;
+
+	for (auto it = settings.constBegin(); it != settings.constEnd(); ++it) {
+		if (!it.value().canConvert<QVariantMap>()) continue;
+
+		auto group = it.value().toMap();
+		QVariantMap toChange;
+		QVariantMap toRemove;
+		for (auto jt = group.constBegin(); jt != group.constEnd(); ++jt) {
+			if (jt.value().isNull()) {
+				toRemove.insert(jt.key(), QVariant());
+			} else {
+				auto converted = settingTypeFromQml(it.key(), jt.key(), jt.value());
+				if (!converted.isValid()) failedSettings.append(it.key() + "." + jt.key());
+				else toChange.insert(jt.key(), converted);
+			}
+		}
+		if (!toChange.isEmpty()) changedSettings.insert(it.key(), toChange);
+		if (!toRemove.isEmpty()) removedSettings.insert(it.key(), toRemove);
+	}
+
+	return changedSettings;
+}
+
+NMSettingsMap wifiConnectionSettings(
+    const QString& ssid,
+    WifiSecurityType::Enum security,
+    const QVariantMap& credentials,
+    bool hidden,
+    QStringList& errors
+) {
+	if (ssid.isEmpty()) {
+		errors.append("ssid is required");
+		return {};
+	}
+
+	QVariantMap wireless {{"ssid", ssid}};
+	if (hidden) wireless.insert("hidden", true);
+
+	QVariantMap qmlSettings {
+	    {"connection", QVariantMap {{"id", ssid}, {"type", "802-11-wireless"}}},
+	    {"802-11-wireless", wireless},
+	};
+
+	const auto requirePsk = [&](const char* keyMgmt) {
+		QVariantMap sec {{"key-mgmt", QString::fromLatin1(keyMgmt)}};
+		const auto psk = credentials.value("psk").toString();
+		if (psk.isEmpty()) errors.append("credentials.psk is required for this security type");
+		else sec.insert("psk", psk);
+		qmlSettings.insert("802-11-wireless-security", sec);
+	};
+
+	switch (security) {
+	case WifiSecurityType::Open:
+	case WifiSecurityType::Unknown:
+		// Open network: no security group.
+		break;
+	case WifiSecurityType::Owe:
+		qmlSettings.insert("802-11-wireless-security", QVariantMap {{"key-mgmt", "owe"}});
+		break;
+	case WifiSecurityType::WpaPsk:
+	case WifiSecurityType::Wpa2Psk: requirePsk("wpa-psk"); break;
+	case WifiSecurityType::Sae: requirePsk("sae"); break;
+	case WifiSecurityType::StaticWep: {
+		QVariantMap sec {{"key-mgmt", "none"}, {"auth-alg", "open"}};
+		const auto key = credentials.value("wepKey").toString();
+		if (key.isEmpty()) errors.append("credentials.wepKey is required for a WEP network");
+		else sec.insert("wep-key0", key);
+		qmlSettings.insert("802-11-wireless-security", sec);
+		break;
+	}
+	case WifiSecurityType::Wpa2Eap:
+	case WifiSecurityType::WpaEap:
+	case WifiSecurityType::Wpa3SuiteB192:
+	case WifiSecurityType::DynamicWep:
+	case WifiSecurityType::Leap:
+		// TODO: build the 802-1x group (eap method, identity, password, phase2, certs) from
+		// credentials once enterprise support is implemented.
+		errors.append("enterprise (802.1x) networks are not yet implemented");
+		return {};
+	}
+
+	if (!errors.isEmpty()) return {};
+
+	NMSettingsMap removedSettings; // Unused: a new connection has nothing to remove.
+	QStringList failedSettings;
+	auto settings = settingsMapFromQml(qmlSettings, removedSettings, failedSettings);
+	for (const auto& failed: failedSettings) errors.append("failed to convert " + failed);
+	return settings;
+}
+
 // Some NMSettingsMap setting types must be converted to a type that is supported by QML.
 // Although QByteArrays can be represented in QML, we convert them to strings for convenience.
 QVariant settingTypeToQml(const QVariant& value) {

--- a/src/network/nm/utils.hpp
+++ b/src/network/nm/utils.hpp
@@ -47,6 +47,23 @@ void manualSettingDemarshall(NMSettingsMap& map);
 
 QVariant settingTypeFromQml(const QString& group, const QString& key, const QVariant& value);
 
+NMSettingsMap settingsMapFromQml(
+    const QVariantMap& settings,
+    NMSettingsMap& removedSettings,
+    QStringList& failedSettings
+);
+
+// Builds the NMSettingsMap for a new Wi-Fi connection profile, dispatching on the security type to
+// set the appropriate key-mgmt and pull the relevant fields out of credentials. Any missing or
+// unsupported requirement is appended to errors, in which case the returned map should not be used.
+NMSettingsMap wifiConnectionSettings(
+    const QString& ssid,
+    WifiSecurityType::Enum security,
+    const QVariantMap& credentials,
+    bool hidden,
+    QStringList& errors
+);
+
 QVariant settingTypeToQml(const QVariant& value);
 
 QDateTime clockBootTimeToDateTime(qint64 clockBootTime);

--- a/src/network/nm/wireless.cpp
+++ b/src/network/nm/wireless.cpp
@@ -269,6 +269,29 @@ void NMWirelessDevice::bindFrontend() {
 	};
 	frontend->bindableMode().setBinding(translateMode);
 	this->bindableScanning().setBinding([frontend]() { return frontend->scannerEnabled(); });
+
+	QObject::connect(
+	    frontend,
+	    &WifiDevice::requestAddNetwork,
+	    this,
+	    &NMWirelessDevice::onAddNetworkRequested
+	);
+}
+
+void NMWirelessDevice::onAddNetworkRequested(
+    const QString& ssid,
+    WifiSecurityType::Enum security,
+    const QVariantMap& credentials,
+    bool hidden
+) {
+	QStringList errors;
+	auto settings = wifiConnectionSettings(ssid, security, credentials, hidden, errors);
+	if (!errors.isEmpty()) {
+		qCWarning(logNetworkManager) << "Failed to add network" << ssid << ":" << errors.join("; ");
+		return;
+	}
+	emit this
+	    ->addAndActivateConnection(settings, QDBusObjectPath(this->path()), QDBusObjectPath("/"));
 }
 
 bool NMWirelessDevice::isValid() const {

--- a/src/network/nm/wireless.hpp
+++ b/src/network/nm/wireless.hpp
@@ -67,6 +67,12 @@ private slots:
 	void onActiveConnectionLoaded(NMActiveConnection* active);
 	void onScanTimeout();
 	void onScanningChanged(bool scanning);
+	void onAddNetworkRequested(
+	    const QString& ssid,
+	    WifiSecurityType::Enum security,
+	    const QVariantMap& credentials,
+	    bool hidden
+	);
 
 private:
 	void registerAccessPoint(const QString& path);

--- a/src/network/wifi.cpp
+++ b/src/network/wifi.cpp
@@ -38,6 +38,15 @@ void WifiNetwork::connectWithPsk(const QString& psk) {
 
 WifiDevice::WifiDevice(QObject* parent): NetworkDevice(DeviceType::Wifi, parent) {};
 
+void WifiDevice::addNetwork(
+    const QString& ssid,
+    WifiSecurityType::Enum security,
+    const QVariantMap& credentials,
+    bool hidden
+) {
+	emit this->requestAddNetwork(ssid, security, credentials, hidden);
+}
+
 void WifiDevice::setScannerEnabled(bool enabled) {
 	if (this->bScannerEnabled == enabled) return;
 	this->bScannerEnabled = enabled;

--- a/src/network/wifi.cpp
+++ b/src/network/wifi.cpp
@@ -1,6 +1,7 @@
 #include "wifi.hpp"
 #include <utility>
 
+#include <qcontainerfwd.h>
 #include <qdebug.h>
 #include <qlogging.h>
 #include <qloggingcategory.h>

--- a/src/network/wifi.hpp
+++ b/src/network/wifi.hpp
@@ -70,12 +70,57 @@ class WifiDevice: public NetworkDevice {
 public:
 	explicit WifiDevice(QObject* parent = nullptr);
 
+	/// Create a new connection profile for a Wi-Fi network and immediately activate it. This is how
+	/// to connect to a network with no pre-existing profile that isn't currently visible, such as a
+	/// hidden network or one entered by hand.
+	///
+	/// The keys required in @@credentials depend on the @@WifiSecurityType:
+	/// - `Open` / `Owe`: none - @@credentials may be omitted.
+	/// - `WpaPsk` / `Wpa2Psk` / `Sae`: `psk` - the pre-shared passphrase.
+	/// - `StaticWep`: `wepKey` - the WEP key.
+	/// - `WpaEap` / `Wpa2Eap` (enterprise): `eap` - the EAP method (`peap`, `ttls`, or `tls`) and
+	///   `identity` - the username. Then, depending on the method: `password` for `peap`/`ttls`
+	///   (with optional `anonymousIdentity` and `phase2Auth`, e.g. `mschapv2`), or `clientCert`,
+	///   `privateKey`, and `privateKeyPassword` for `tls`. `caCert` is optional for all methods.
+	///
+	/// For example, to connect to a hidden WPA2 network:
+	/// ```qml
+	/// wifiDevice.addNetwork("Example", WifiSecurityType.Wpa2Psk, { "psk": "hunter2" }, true);
+	/// ```
+	///
+	/// An open network, with no credentials:
+	/// ```qml
+	/// wifiDevice.addNetwork("Example", WifiSecurityType.Open);
+	/// ```
+	///
+	/// Or a PEAP enterprise network:
+	/// ```qml
+	/// wifiDevice.addNetwork("Example", WifiSecurityType.Wpa2Eap, {
+	///     "eap": "peap",
+	///     "identity": "user",
+	///     "password": "hunter2",
+	///     "phase2Auth": "mschapv2"
+	/// });
+	/// ```
+	Q_INVOKABLE void addNetwork(
+	    const QString& ssid,
+	    WifiSecurityType::Enum security,
+	    const QVariantMap& credentials = {},
+	    bool hidden = false
+	);
+
 	QBindable<bool> bindableScannerEnabled() { return &this->bScannerEnabled; }
 	[[nodiscard]] bool scannerEnabled() const { return this->bScannerEnabled; }
 	void setScannerEnabled(bool enabled);
 	QBindable<WifiDeviceMode::Enum> bindableMode() { return &this->bMode; }
 
 signals:
+	QSDOC_HIDE void requestAddNetwork(
+	    const QString& ssid,
+	    WifiSecurityType::Enum security,
+	    const QVariantMap& credentials,
+	    bool hidden
+	);
 	void modeChanged();
 	void scannerEnabledChanged(bool enabled);
 

--- a/src/network/wifi.hpp
+++ b/src/network/wifi.hpp
@@ -78,10 +78,12 @@ public:
 	/// - `Open` / `Owe`: none - @@credentials may be omitted.
 	/// - `WpaPsk` / `Wpa2Psk` / `Sae`: `psk` - the pre-shared passphrase.
 	/// - `StaticWep`: `wepKey` - the WEP key.
-	/// - `WpaEap` / `Wpa2Eap` (enterprise): `eap` - the EAP method (`peap`, `ttls`, or `tls`) and
-	///   `identity` - the username. Then, depending on the method: `password` for `peap`/`ttls`
-	///   (with optional `anonymousIdentity` and `phase2Auth`, e.g. `mschapv2`), or `clientCert`,
-	///   `privateKey`, and `privateKeyPassword` for `tls`. `caCert` is optional for all methods.
+	/// - `WpaEap` / `Wpa2Eap` / `Wpa3SuiteB192` / `DynamicWep` (enterprise): `eap` - the EAP method
+	///   (`peap`, `ttls`, or `tls`) and `identity` - the username. Then, depending on the method:
+	///   `password` for `peap`/`ttls` (with optional `anonymousIdentity` and `phase2Auth`, e.g.
+	///   `mschapv2`), or `clientCert`, `privateKey`, and `privateKeyPassword` for `tls`. `caCert` is
+	///   optional for all methods. Certificate fields accept a filesystem path.
+	/// - `Leap`: `identity` and `password`.
 	///
 	/// For example, to connect to a hidden WPA2 network:
 	/// ```qml

--- a/src/network/wifi.hpp
+++ b/src/network/wifi.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <qcontainerfwd.h>
 #include <qobject.h>
 #include <qproperty.h>
 #include <qqmlintegration.h>


### PR DESCRIPTION
Currently, you can only connect to a wireless network that is exposed in the `NetworkDevice::networks` property. This PR adds the ability to connect to networks that do not expose their SSID, or that don't show up in the networks list for whatever reason.

This is done via a new `WifiDevice::addNetwork` method, which takes the SSID, security type and options, and whether or not the network is hidden.

Example usage:
```qml
Item {
    required property WifiDevice wifi
    
    Component.onCompleted: {
        wifi.addNetwork("some_ssid", WifiSecurityType.Wpa2Psk, {
            psk: "some_password"
        });
    }
}
```