### PR TITLE
fix: stop watching parent directories in DesktopEntryMonitor

### DIFF
--- a/src/core/desktopentrymonitor.cpp
+++ b/src/core/desktopentrymonitor.cpp
@@ -46,7 +46,7 @@ DesktopEntryMonitor::DesktopEntryMonitor(QObject* parent): QObject(parent) {
 void DesktopEntryMonitor::startMonitoring() {
 	for (const auto& path: DesktopEntryManager::desktopPaths()) {
 		if (!QDir(path).exists()) continue;
-		addPathAndParents(this->watcher, path);
+		this->watcher.addPath(path);
 		this->scanAndWatch(path);
 	}
 }


### PR DESCRIPTION
### Problem

`DesktopEntryMonitor::startMonitoring()` calls `addPathAndParents()`, which adds `QFileSystemWatcher` watches on every parent directory of each desktop entry path — all the way up to `/`. For example, for `/usr/share/applications` it watches `/usr/share`, `/usr`, and `/`.

Watching `/` means `QFileSystemWatcher::directoryChanged` fires on **any filesystem event anywhere on the system** — a temp file in `/tmp`, a cache write, a `.config` change — triggering a full rescan of all desktop entries. This causes:

- Spurious rescans at ~3 Hz even when no `.desktop` file has changed
- 45%+ CPU at idle
- `log.qslog` growing to multiple GB from "Directory change detected" spam
- Fill tmpfs under `$XDG_RUNTIME_DIR` (reported to fill 3.2 GB in ~16 h)

### Fix

Replace `addPathAndParents()` with a plain `watcher.addPath(path)` so only the actual desktop-entry directories are watched. `scanAndWatch()` independently handles subdirectory monitoring.

### Result

Measured on NVIDIA RTX 4090, Hyprland (Wayland), Arch Linux, Qt 6.11, ~366 .desktop files:

| Before | After |
|--------|-------|
| 45–65% CPU at idle | ~19% CPU (scene graph sync, no rescans) |
| 1–3 rescans per second | 0 rescans (initial scan only) |
| Log grows to GB | Clean log |
| Every filesystem event triggers rescan | Only `.desktop` dir changes trigger rescan |

### Related

Closes #757 — "DesktopEntries fires spurious rescan events, growing log.qslog by multiple GB"