### PR TITLE
service/notifications: support activation tokens

### DIFF
--- a/changelog/next.md
+++ b/changelog/next.md
@@ -12,3 +12,5 @@
 - Fixed unhandled notifications sending `NotificationClosed` out of order.
 - Fixed `qs kill` not waiting for the process to exit.
 - Fixed IPC calls from children of a crashed and relaunched process crashing.
+- Notification actions can now provide activation tokens so applications can focus their associated
+  windows.

--- a/src/services/notifications/notification.cpp
+++ b/src/services/notifications/notification.cpp
@@ -42,10 +42,14 @@ QString NotificationCloseReason::toString(NotificationCloseReason::Enum value) {
 QString NotificationAction::identifier() const { return this->mIdentifier; }
 QString NotificationAction::text() const { return this->mText; }
 
-void NotificationAction::invoke() {
+void NotificationAction::invoke(const QString& activationToken) {
 	if (this->notification->isRetained()) {
 		qCritical() << "Cannot invoke destroyed notification" << this;
 		return;
+	}
+
+	if (!activationToken.isEmpty()) {
+		NotificationServer::instance()->ActivationToken(this->notification->id(), activationToken);
 	}
 
 	NotificationServer::instance()->ActionInvoked(this->notification->id(), this->mIdentifier);

--- a/src/services/notifications/notification.hpp
+++ b/src/services/notifications/notification.hpp
@@ -258,7 +258,11 @@ public:
 	    , mText(std::move(text)) {}
 
 	/// Invoke the action. If @@Notification.resident is false it will be dismissed.
-	Q_INVOKABLE void invoke();
+	///
+	/// If `activationToken` is supplied, it is sent to the application before the action is
+	/// invoked. The application can use the token to focus the window associated with the
+	/// notification.
+	Q_INVOKABLE void invoke(const QString& activationToken = QString());
 
 	[[nodiscard]] QString identifier() const;
 	[[nodiscard]] QString text() const;

--- a/src/services/notifications/server.hpp
+++ b/src/services/notifications/server.hpp
@@ -61,6 +61,7 @@ signals:
 	// NOLINTBEGIN
 	void NotificationClosed(quint32 id, quint32 reason);
 	void ActionInvoked(quint32 id, QString action);
+	void ActivationToken(quint32 id, QString activationToken);
 	void NotificationReplied(quint32 id, QString replyText);
 	// NOLINTEND
 


### PR DESCRIPTION
## Summary

- implement the `ActivationToken` signal already declared by the notification D-Bus XML
- let QML call `NotificationAction.invoke(activationToken)` while preserving parameterless `invoke()`
- emit a non-empty activation token immediately before `ActionInvoked`

## User-visible behavior

Notification-center QML can pass a Wayland xdg-activation token (or X11 startup ID) when invoking an action. The notified application receives that token before the action signal and can use it to focus the associated window.

```qml
action.invoke(activationToken)
```

Existing `action.invoke()` calls remain unchanged.

## Validation

- `nix develop --command cmake -GNinja -B /tmp/quickshell-activation-pr.a9VfrE -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DNO_PCH=ON -DBUILD_TESTING=ON`
- `nix develop --command cmake --build /tmp/quickshell-activation-pr.a9VfrE` (full build, 1336 targets)
- `nix develop --command ctest --test-dir /tmp/quickshell-activation-pr.a9VfrE --output-on-failure` (9/9 passed)
- `clang-format -Werror --dry-run src/services/notifications/notification.cpp src/services/notifications/notification.hpp src/services/notifications/server.hpp`
- `clang-tidy --load="$TIDYFOX" -p /tmp/quickshell-activation-pr.a9VfrE src/services/notifications/notification.cpp`
- generated QML metadata contains both `invoke()` and `invoke(string)`; the generated D-Bus adaptor auto-relays `ActivationToken`
