### PR TITLE
services/notifications: document tracked/urgency fields reference gaps

### DIFF
--- a/src/services/notifications/notification.hpp
+++ b/src/services/notifications/notification.hpp
@@ -72,6 +72,15 @@ class Notification
 	Q_PROPERTY(quint32 id READ id CONSTANT);
 	/// If the notification is tracked by the notification server.
 	///
+	/// Setting this property to true means that the server will not destroy
+	/// this notification object immediately after it has been emitted.
+	/// > [!INFO] The server still may set this to false by itself
+	/// > e.g. when the sending application is being closed
+	///
+	/// > [!WARNING] If you don't untrack the notification by either calling 
+	/// > @@dismiss() or @@expire() the notification server will keep the notification 
+	/// > object alive until you do so. 
+	/// 	
 	/// Setting this property to false is equivalent to calling @@dismiss().
 	Q_PROPERTY(bool tracked READ isTracked WRITE setTracked NOTIFY trackedChanged);
 	/// If this notification was carried over from the last generation
@@ -90,6 +99,7 @@ class Notification
 	/// The image associated with this notification, or "" if none.
 	Q_PROPERTY(QString summary READ default NOTIFY summaryChanged BINDABLE bindableSummary);
 	Q_PROPERTY(QString body READ default NOTIFY bodyChanged BINDABLE bindableBody);
+	/// See @@NotificationUrgency for details
 	Q_PROPERTY(qs::service::notifications::NotificationUrgency::Enum urgency READ default NOTIFY urgencyChanged BINDABLE bindableUrgency);
 	/// Actions that can be taken for this notification.
 	Q_PROPERTY(QList<qs::service::notifications::NotificationAction*> actions READ actions NOTIFY actionsChanged);


### PR DESCRIPTION
Notification.urgency - Added missing reference to NotificationUrgency enum

Notification.tracked - Updated description to inform user that NotificationServer may set this flag by itself. Also added a warning that if this flag is manually set to true, the notification will be destroyed only after the user explicitly expires/dismisses it or when the NotificationServer when it is notified by sender application.

In depth explanation of commit:
I've had some issues with RetainableLock and Retainable properties of Notification object, it would get destroyed after scope of onNotification. After some time I started digging in the source code and I stumbled upon the tracked flag which by manually changing to true made the NotificationManager not destroy the Notification object immediately after emitting it.

I think that previous description of the tracked field wasn't telling the user all useful information about that flag (especially that NotificationServer can set it to false).