### PR TITLE
io: deregister IPC handlers without re-resolving the generation

### DIFF
--- a/src/io/ipchandler.cpp
+++ b/src/io/ipchandler.cpp
@@ -304,6 +304,18 @@ void IpcHandler::onSignalTriggered(const QString& signal, const QString& value) 
 void IpcHandler::updateRegistration(bool destroying) {
 	if (!this->complete) return;
 
+	// Deregister through the registry this handler actually joined. Re-resolving
+	// the generation fails once the object's QML context is gone, which is the
+	// case during destruction, and would leave the target held forever.
+	if (this->registeredState.enabled && this->registeredRegistry != nullptr) {
+		auto* registry = this->registeredRegistry;
+		registry->deregisterHandler(this);
+		this->registeredRegistry = nullptr;
+		qCDebug(logIpcHandler) << "Deregistered" << this << "from registry" << registry;
+	}
+
+	if (!this->targetState.enabled || this->targetState.target.isEmpty()) return;
+
 	auto* generation = EngineGeneration::findObjectGeneration(this);
 
 	if (!generation) {
@@ -315,15 +327,19 @@ void IpcHandler::updateRegistration(bool destroying) {
 	}
 
 	auto* registry = IpcHandlerRegistry::forGeneration(generation);
+	registry->registerHandler(this);
+	this->registeredRegistry = registry;
+	qCDebug(logIpcHandler) << "Registered" << this << "to registry" << registry;
+}
 
-	if (this->registeredState.enabled) {
-		registry->deregisterHandler(this);
-		qCDebug(logIpcHandler) << "Deregistered" << this << "from registry" << registry;
-	}
-
-	if (this->targetState.enabled && !this->targetState.target.isEmpty()) {
-		registry->registerHandler(this);
-		qCDebug(logIpcHandler) << "Registered" << this << "to registry" << registry;
+IpcHandlerRegistry::~IpcHandlerRegistry() {
+	// The generation owns this registry and may outlive nothing: clear the back
+	// pointers so a handler destroyed later does not touch freed memory.
+	for (const auto& handlers: this->knownHandlers) {
+		for (auto* handler: handlers) {
+			handler->registeredRegistry = nullptr;
+			handler->registeredState = IpcHandler::RegistrationState(false);
+		}
 	}
 }
 

--- a/src/io/ipchandler.hpp
+++ b/src/io/ipchandler.hpp
@@ -265,6 +265,8 @@ private:
 
 	RegistrationState registeredState;
 	RegistrationState targetState {true};
+	// Deregistration cannot re-resolve the generation, which is gone by then.
+	IpcHandlerRegistry* registeredRegistry = nullptr;
 	bool complete = false;
 
 	QHash<QString, IpcFunction> functionMap;
@@ -276,6 +278,8 @@ private:
 
 class IpcHandlerRegistry: public EngineGenerationExt {
 public:
+	~IpcHandlerRegistry() override;
+
 	static IpcHandlerRegistry* forGeneration(EngineGeneration* generation);
 
 	void registerHandler(IpcHandler* handler);


### PR DESCRIPTION
`IpcHandler::updateRegistration()` resolves the registry through `EngineGeneration::findObjectGeneration()` for both registration *and* deregistration. That lookup walks up parents for a `QQmlContext`, which is already gone by the time a handler is destroyed, so it returns null and the function returns before deregistering:

```cpp
auto* generation = EngineGeneration::findObjectGeneration(this);

if (!generation) {
    if (!destroying) {
        qmlWarning(this) << "Unable to identify engine generation, cannot register.";
    }

    return;   // deregistration never happens
}
```

The `destroying` flag only suppresses the warning, so the failure is silent. The handler stays in `IpcHandlerRegistry` forever holding its target, and every later registration for that target collides with a destroyed object — the collision warning fires, and IPC calls are answered by the dead handler.

`generation.cpp` already anticipates this case, in a comment directly above the lookup:

```cpp
// Objects can still attempt to find their generation after it has been destroyed.
// if (g_generations.size() == 1) return EngineGeneration::currentGeneration();
```

### Measurement

Found via a shell that reloads plugins at runtime (Omarchy). Adding a temporary trace at the top of `updateRegistration` produced, on the unmodified tree:

```
QSDIAG target=osd gen=0x0 destroying=1
QSDIAG target=osd gen=0x0 destroying=1
QSDIAG target=osd gen=0x0 destroying=1
```

`gen=0x0` during destruction, three times — three leaked registrations. Instrumenting the QML object's lifecycle showed strictly sequential `created → destroyed → collision → created`: never two live instances, just one dead registration squatting the target.

### The change

Remember the registry a handler joined and deregister through it. Registration still resolves the generation exactly as before, so nothing changes on that path.

`EngineGeneration` deletes its extensions, so the registry can be destroyed before its handlers. `~IpcHandlerRegistry()` therefore clears the back pointers on everything in `knownHandlers`, so this doesn't trade a leak for a dangling pointer.

### Verification

- `ctest`: **9/9 pass** with the change (also 9/9 before it).
- Against the reloading shell, same commit and machine, only this patch differing:

  | quickshell | collisions | result |
  |---|---|---|
  | unmodified | 3 | fails |
  | patched | 0 | passes |
  | patched, rerun | 0 | passes |

Built and tested on aarch64 (Arch Linux ARM), Qt 6.11.1, at `43d4fa9`.

### What I could not do

I could not reduce this to a minimal standalone Quickshell config. Three shapes — a `sourceComponent` Loader toggling, an async file-URL Loader plus `Qt.clearComponentCache()`, and driving real config reloads by editing a watched file — all deregister correctly and produce zero collisions. A fourth (a `Loader` held as a property of an `Instantiator` delegate) does produce the same collision warning, but for a different reason: there `updateRegistration` is never called at all, so it looks like the objects are never destroyed rather than destroyed-without-deregistering. I did not want to present that as a reproduction of this bug.

So the reproduction I have is the reloading shell, and the direct evidence is the `gen=0x0` trace above. Happy to dig further into the standalone case, or to adjust the approach if you'd rather fix the lookup in `findObjectGeneration` (that commented-out fallback) than track the registry per handler.
