### PR TITLE
core/qmlscreen: expose the screen refresh rate

### DIFF
--- a/changelog/next.md
+++ b/changelog/next.md
@@ -1,3 +1,7 @@
+## New Features
+
+- Added a refreshRate property to ShellScreen.
+
 ## Bug Fixes
 
 - Fixed ScreencopyView not displaying when only lock surfaces are shown.

--- a/src/core/qmlscreen.cpp
+++ b/src/core/qmlscreen.cpp
@@ -16,6 +16,7 @@ QuickshellScreenInfo::QuickshellScreenInfo(QObject* parent, QScreen* screen)
 		QObject::connect(this->screen, &QScreen::geometryChanged, this, &QuickshellScreenInfo::geometryChanged);
 		QObject::connect(this->screen, &QScreen::physicalDotsPerInchChanged, this, &QuickshellScreenInfo::physicalPixelDensityChanged);
 		QObject::connect(this->screen, &QScreen::logicalDotsPerInchChanged, this, &QuickshellScreenInfo::logicalPixelDensityChanged);
+		QObject::connect(this->screen, &QScreen::refreshRateChanged, this, &QuickshellScreenInfo::refreshRateChanged);
 		QObject::connect(this->screen, &QScreen::orientationChanged, this, &QuickshellScreenInfo::orientationChanged);
 		QObject::connect(this->screen, &QScreen::primaryOrientationChanged, this, &QuickshellScreenInfo::primaryOrientationChanged);
 		QObject::connect(this->screen, &QObject::destroyed, this, &QuickshellScreenInfo::screenDestroyed);
@@ -121,6 +122,15 @@ qreal QuickshellScreenInfo::devicePixelRatio() const {
 	}
 
 	return this->screen->devicePixelRatio();
+}
+
+qreal QuickshellScreenInfo::refreshRate() const {
+	if (this->screen == nullptr) {
+		this->warnDangling();
+		return 0.0;
+	}
+
+	return this->screen->refreshRate();
 }
 
 Qt::ScreenOrientation QuickshellScreenInfo::orientation() const {

--- a/src/core/qmlscreen.hpp
+++ b/src/core/qmlscreen.hpp
@@ -43,6 +43,12 @@ class QuickshellScreenInfo: public QObject {
 	Q_PROPERTY(qreal logicalPixelDensity READ logicalPixelDensity NOTIFY logicalPixelDensityChanged);
 	/// The ratio between physical pixels and device-independent (scaled) pixels.
 	Q_PROPERTY(qreal devicePixelRatio READ devicePixelRatio NOTIFY physicalPixelDensityChanged);
+	/// The refresh rate of the screen's current mode, in hertz.
+	///
+	/// This is the rate reported for the current mode, not a measurement of when
+	/// frames are actually presented. With variable refresh rate enabled the two
+	/// can differ substantially.
+	Q_PROPERTY(qreal refreshRate READ refreshRate NOTIFY refreshRateChanged);
 	Q_PROPERTY(Qt::ScreenOrientation orientation READ orientation NOTIFY orientationChanged);
 	Q_PROPERTY(Qt::ScreenOrientation primaryOrientation READ primaryOrientation NOTIFY primaryOrientationChanged);
 	// clang-format on
@@ -62,6 +68,7 @@ public:
 	[[nodiscard]] qreal physicalPixelDensity() const;
 	[[nodiscard]] qreal logicalPixelDensity() const;
 	[[nodiscard]] qreal devicePixelRatio() const;
+	[[nodiscard]] qreal refreshRate() const;
 	[[nodiscard]] Qt::ScreenOrientation orientation() const;
 	[[nodiscard]] Qt::ScreenOrientation primaryOrientation() const;
 
@@ -77,6 +84,7 @@ signals:
 	void geometryChanged();
 	void physicalPixelDensityChanged();
 	void logicalPixelDensityChanged();
+	void refreshRateChanged();
 	void orientationChanged();
 	void primaryOrientationChanged();
 


### PR DESCRIPTION
`ShellScreen` exposes a screen's geometry and density characteristics but not
its refresh rate, so QML has no way to find out how often a screen refreshes.
Shells that pace animations, budget work per frame, or reason about frame
timing currently have to get it from the compositor over an out-of-band
channel, if they can get it at all.

`QScreen` already tracks the value and emits a change signal for it, and it is
populated on Wayland. This forwards both, in the same shape as the surrounding
properties: a `nullptr` guard returning `0.0` for the dangling-screen case, and
a signal-to-signal connection alongside the existing ones in the constructor.

The doc comment notes that this is the rate reported for the current mode
rather than a measurement of when frames are actually presented, since the two
diverge under variable refresh and the distinction matters for the timing use
case that motivates the property.

### Testing

- `just fmt` produces no changes; `clang-format -Werror --dry-run` passes on both files.
- `just lint-changed` equivalent (clang-tidy with tidyfox) reports no warnings in
  either file. Verified the lint was actually running on them by temporarily
  dropping a `this->` in the new getter and confirming `tidyfox-explicit-thisptr`
  caught it.
- `just test` passes 9/9.
- Checked at runtime under niri: `ShellScreen.refreshRate` reads `59.999` for a
  DP-1 output whose mode niri reports as 59.999 Hz. It read `undefined` before.

`QScreen::refreshRate` and `refreshRateChanged` are unguarded and long predate
Qt 6, so this needs no version gating against the 6.6.0 minimum.

### Contributions

- Claude Opus 5  + GPT 5.6-sol helped with the initial investigation, authoring the patch,
  testing / validation, and write the commit message + PR draft description
- The lazy human (me) reviewed the code line-by-line, checked to make sure we are abiding by the
  contributers guidelines and added this section to provide some clarity on who did what, and
  handled the actual PR submission.
