### PR TITLE
service/pam: fix invalid free of responseArray in conversation fail path

### DIFF
--- a/src/services/pam/subprocess.cpp
+++ b/src/services/pam/subprocess.cpp
@@ -201,6 +201,6 @@ int PamSubprocess::conversation(
 	return PAM_SUCCESS;
 
 fail:
-	free(responseArray); // NOLINT
+	free(responses); // NOLINT
 	_exit(1);
 }


### PR DESCRIPTION
Fixes #977.

## What happens

`PamSubprocess::conversation()` allocates the response array it returns to libpam:

```cpp
// freed by libc so must be alloc'd by it.
auto* responses = static_cast<pam_response*>(calloc(msgCount, sizeof(pam_response))); // NOLINT
```

On success the array is handed back through the out-parameter (`*responseArray = responses`). On the failure path, however, the code frees the **out-parameter itself** — `responseArray`, a `pam_response**` pointing into libpam's stack frame — instead of the allocated array:

```cpp
fail:
	free(responseArray); // NOLINT
	_exit(1);
```

Freeing a stack address is undefined behavior; under jemalloc it faults while walking allocator metadata for the bogus pointer and kills the PAM subprocess — taking the whole shell down with it.

Trigger observed in #977: lock screen starts fingerprint auth (`pam_fprintd`) → verification times out → the parent gives up on the conversation and closes the IPC pipes → the subprocess's next pipe write fails → `goto fail` → invalid `free()` → SIGSEGV at `subprocess.cpp:204`.

## The fix

Free what the function actually allocated:

```diff
 fail:
-	free(responseArray); // NOLINT
+	free(responses); // NOLINT
 	_exit(1);
```

`responses` is ours to release on this path: it is `calloc`'d by libc specifically so libpam can free it later (per the comment above the allocation), and ownership only transfers to libpam on the success path via `*responseArray = responses`. On `fail:` nothing outside the function has seen it yet.

## Testing

Built and deployed on Arch (quickshell-git 0.3.1.r0.g1a4716c with this patch). The machine's fingerprint reader fails every attempt (PAM code 9, ~30 s retry loop), which is what kept exercising the abort race: two shell-killing SIGSEGVs earlier the same day, both faulting at `subprocess.cpp:204` (coredumps referenced in #977). Since the patched build has been running, the identical retry loop continues without any further crash of the shell.
