### PR TITLE
networking: add frequency, bssid, and other details to WifiNetwork

### DIFF
--- a/changelog/next.md
+++ b/changelog/next.md
@@ -1,3 +1,7 @@
+## Features
+
+- Added `frequency`, `bssid`, `maxBitrate`, `bandwidth`, and `lastSeen` properties to @@Networking.WifiNetwork.
+
 ## Bug Fixes
 
 - Fixed main process crashes on pam subprocess misbehavior.

--- a/src/network/nm/accesspoint.hpp
+++ b/src/network/nm/accesspoint.hpp
@@ -50,6 +50,11 @@ public:
 	[[nodiscard]] QString address() const;
 	[[nodiscard]] QByteArray ssid() const { return this->bSsid; }
 	[[nodiscard]] quint8 signalStrength() const { return this->bSignalStrength; }
+	[[nodiscard]] quint32 frequency() const { return this->bFrequency; }
+	[[nodiscard]] QString hwAddress() const { return this->bHwAddress; }
+	[[nodiscard]] quint32 maxBitrate() const { return this->bMaxBitrate; }
+	[[nodiscard]] qint32 lastSeen() const { return this->bLastSeen; }
+	[[nodiscard]] quint32 bandwidth() const { return this->bBandwidth; }
 	[[nodiscard]] NM80211ApFlags::Enum flags() const { return this->bFlags; }
 	[[nodiscard]] NM80211ApSecurityFlags::Enum wpaFlags() const { return this->bWpaFlags; }
 	[[nodiscard]] NM80211ApSecurityFlags::Enum rsnFlags() const { return this->bRsnFlags; }
@@ -61,6 +66,11 @@ signals:
 	void loaded();
 	void ssidChanged(const QByteArray& ssid);
 	void signalStrengthChanged(quint8 signal);
+	void frequencyChanged(quint32 frequency);
+	void hwAddressChanged(const QString& hwAddress);
+	void maxBitrateChanged(quint32 maxBitrate);
+	void lastSeenChanged(qint32 lastSeen);
+	void bandwidthChanged(quint32 bandwidth);
 	void flagsChanged(NM80211ApFlags::Enum flags);
 	void wpaFlagsChanged(NM80211ApSecurityFlags::Enum wpaFlags);
 	void rsnFlagsChanged(NM80211ApSecurityFlags::Enum rsnFlags);
@@ -71,6 +81,11 @@ private:
 	// clang-format off
 	Q_OBJECT_BINDABLE_PROPERTY(NMAccessPoint, QByteArray, bSsid, &NMAccessPoint::ssidChanged);
 	Q_OBJECT_BINDABLE_PROPERTY(NMAccessPoint, quint8, bSignalStrength, &NMAccessPoint::signalStrengthChanged);
+	Q_OBJECT_BINDABLE_PROPERTY(NMAccessPoint, quint32, bFrequency, &NMAccessPoint::frequencyChanged);
+	Q_OBJECT_BINDABLE_PROPERTY(NMAccessPoint, QString, bHwAddress, &NMAccessPoint::hwAddressChanged);
+	Q_OBJECT_BINDABLE_PROPERTY(NMAccessPoint, quint32, bMaxBitrate, &NMAccessPoint::maxBitrateChanged);
+	Q_OBJECT_BINDABLE_PROPERTY(NMAccessPoint, qint32, bLastSeen, &NMAccessPoint::lastSeenChanged);
+	Q_OBJECT_BINDABLE_PROPERTY(NMAccessPoint, quint32, bBandwidth, &NMAccessPoint::bandwidthChanged);
 	Q_OBJECT_BINDABLE_PROPERTY(NMAccessPoint, NM80211ApFlags::Enum, bFlags, &NMAccessPoint::flagsChanged);
 	Q_OBJECT_BINDABLE_PROPERTY(NMAccessPoint, NM80211ApSecurityFlags::Enum, bWpaFlags, &NMAccessPoint::wpaFlagsChanged);
 	Q_OBJECT_BINDABLE_PROPERTY(NMAccessPoint, NM80211ApSecurityFlags::Enum, bRsnFlags, &NMAccessPoint::rsnFlagsChanged);
@@ -80,6 +95,11 @@ private:
 	QS_DBUS_BINDABLE_PROPERTY_GROUP(NMAccessPointAdapter, accessPointProperties);
 	QS_DBUS_PROPERTY_BINDING(NMAccessPoint, pSsid, bSsid, accessPointProperties, "Ssid");
 	QS_DBUS_PROPERTY_BINDING(NMAccessPoint, pSignalStrength, bSignalStrength, accessPointProperties, "Strength");
+	QS_DBUS_PROPERTY_BINDING(NMAccessPoint, pFrequency, bFrequency, accessPointProperties, "Frequency");
+	QS_DBUS_PROPERTY_BINDING(NMAccessPoint, pHwAddress, bHwAddress, accessPointProperties, "HwAddress");
+	QS_DBUS_PROPERTY_BINDING(NMAccessPoint, pMaxBitrate, bMaxBitrate, accessPointProperties, "MaxBitrate");
+	QS_DBUS_PROPERTY_BINDING(NMAccessPoint, pLastSeen, bLastSeen, accessPointProperties, "LastSeen");
+	QS_DBUS_PROPERTY_BINDING(NMAccessPoint, pBandwidth, bBandwidth, accessPointProperties, "Bandwidth");
 	QS_DBUS_PROPERTY_BINDING(NMAccessPoint, pFlags, bFlags, accessPointProperties, "Flags");
 	QS_DBUS_PROPERTY_BINDING(NMAccessPoint, pWpaFlags, bWpaFlags, accessPointProperties, "WpaFlags");
 	QS_DBUS_PROPERTY_BINDING(NMAccessPoint, pRsnFlags, bRsnFlags, accessPointProperties, "RsnFlags");

--- a/src/network/nm/network.cpp
+++ b/src/network/nm/network.cpp
@@ -204,6 +204,12 @@ NMWirelessNetwork::NMWirelessNetwork(const QString& ssid, NetworkDevice* device,
 	QObject::connect(this, &NMWirelessNetwork::referenceApChanged, this, updateSecurity);
 	QObject::connect(this, &NMWirelessNetwork::settingsRemoved, this, checkDisappeared);
 	QObject::connect(this, &NMWirelessNetwork::apRemoved, this, checkDisappeared);
+	QObject::connect(
+	    this,
+	    &NMWirelessNetwork::activeApPathChanged,
+	    this,
+	    &NMWirelessNetwork::updateReferenceAp
+	);
 
 	// Register and bind the frontend WifiNetwork.
 	this->mFrontend = new WifiNetwork(ssid, device, this);
@@ -215,6 +221,11 @@ void NMWirelessNetwork::updateReferenceAp() {
 	if (this->mAccessPoints.isEmpty()) {
 		this->bReferenceAp = nullptr;
 		this->bSignalStrength = 0;
+		this->bFrequency = 0;
+		this->bMaxBitrate = 0;
+		this->bHwAddress = QString();
+		this->bBandwidth = 0;
+		this->bLastSeen = QDateTime();
 		return;
 	}
 
@@ -233,6 +244,15 @@ void NMWirelessNetwork::updateReferenceAp() {
 	if (this->bReferenceAp != selectedAp) {
 		this->bReferenceAp = selectedAp;
 		this->bSignalStrength.setBinding([selectedAp]() { return selectedAp->signalStrength(); });
+		this->bFrequency.setBinding([selectedAp]() { return selectedAp->frequency(); });
+		this->bHwAddress.setBinding([selectedAp]() { return selectedAp->hwAddress(); });
+		this->bMaxBitrate.setBinding([selectedAp]() { return selectedAp->maxBitrate(); });
+		this->bBandwidth.setBinding([selectedAp]() { return selectedAp->bandwidth(); });
+		this->bLastSeen.setBinding([selectedAp]() {
+			const qint32 sec = selectedAp->lastSeen();
+			if (sec <= 0) return QDateTime();
+			return clockBootTimeToDateTime(static_cast<qint64>(sec) * 1000);
+		});
 	}
 }
 
@@ -260,7 +280,11 @@ void NMWirelessNetwork::bindFrontend() {
 	auto translateSignal = [this]() { return this->signalStrength() / 100.0; };
 	frontend->bindableSignalStrength().setBinding(translateSignal);
 	frontend->bindableSecurity().setBinding([this]() { return this->security(); });
-
+	frontend->bindableFrequency().setBinding([this]() { return this->frequency(); });
+	frontend->bindableBssid().setBinding([this]() { return this->hwAddress(); });
+	frontend->bindableMaxBitrate().setBinding([this]() { return this->maxBitrate(); });
+	frontend->bindableBandwidth().setBinding([this]() { return this->bandwidth(); });
+	frontend->bindableLastSeen().setBinding([this]() { return this->lastSeen(); });
 	QObject::connect(frontend, &WifiNetwork::requestConnect, this, [this]() {
 		if (auto* settingsRef = this->referenceSettings()) {
 			emit this->requestActivateConnection(settingsRef->path());

--- a/src/network/nm/network.hpp
+++ b/src/network/nm/network.hpp
@@ -103,6 +103,11 @@ public:
 	// clang-format off
 	[[nodiscard]] QString ssid() const { return this->mSsid; }
 	[[nodiscard]] quint8 signalStrength() const { return this->bSignalStrength; }
+	[[nodiscard]] quint32 frequency() const { return this->bFrequency; }
+	[[nodiscard]] QString hwAddress() const { return this->bHwAddress; }
+	[[nodiscard]] quint32 maxBitrate() const { return this->bMaxBitrate; }
+	[[nodiscard]] quint32 bandwidth() const { return this->bBandwidth; }
+	[[nodiscard]] QDateTime lastSeen() const { return this->bLastSeen; }
 	[[nodiscard]] WifiSecurityType::Enum security() const { return this->bSecurity; }
 	[[nodiscard]] NMAccessPoint* referenceAp() const { return this->bReferenceAp; }
 	[[nodiscard]] QList<NMAccessPoint*> accessPoints() const { return this->mAccessPoints.values(); }
@@ -113,6 +118,11 @@ public:
 signals:
 	void disappeared();
 	void signalStrengthChanged(quint8 signal);
+	void frequencyChanged(quint32 frequency);
+	void hwAddressChanged(const QString& hwAddress);
+	void maxBitrateChanged(quint32 maxBitrate);
+	void bandwidthChanged(quint32 bandwidth);
+	void lastSeenChanged(const QDateTime& lastSeen);
 	void securityChanged(WifiSecurityType::Enum security);
 	void activeApPathChanged(QString path);
 	void referenceApChanged(NMAccessPoint* ap);
@@ -130,6 +140,11 @@ private:
 	// clang-format off
 	Q_OBJECT_BINDABLE_PROPERTY(NMWirelessNetwork, WifiSecurityType::Enum, bSecurity, &NMWirelessNetwork::securityChanged);
 	Q_OBJECT_BINDABLE_PROPERTY(NMWirelessNetwork, quint8, bSignalStrength, &NMWirelessNetwork::signalStrengthChanged);
+	Q_OBJECT_BINDABLE_PROPERTY(NMWirelessNetwork, quint32, bFrequency, &NMWirelessNetwork::frequencyChanged);
+	Q_OBJECT_BINDABLE_PROPERTY(NMWirelessNetwork, QString, bHwAddress, &NMWirelessNetwork::hwAddressChanged);
+	Q_OBJECT_BINDABLE_PROPERTY(NMWirelessNetwork, quint32, bMaxBitrate, &NMWirelessNetwork::maxBitrateChanged);
+	Q_OBJECT_BINDABLE_PROPERTY(NMWirelessNetwork, quint32, bBandwidth, &NMWirelessNetwork::bandwidthChanged);
+	Q_OBJECT_BINDABLE_PROPERTY(NMWirelessNetwork, QDateTime, bLastSeen, &NMWirelessNetwork::lastSeenChanged);
 	Q_OBJECT_BINDABLE_PROPERTY(NMWirelessNetwork, QString, bActiveApPath, &NMWirelessNetwork::activeApPathChanged);
 	Q_OBJECT_BINDABLE_PROPERTY(NMWirelessNetwork, NMAccessPoint*, bReferenceAp, &NMWirelessNetwork::referenceApChanged);
 	// clang-format on

--- a/src/network/test/manual/network.qml
+++ b/src/network/test/manual/network.qml
@@ -237,6 +237,26 @@ Scope {
                                         text: `| Signal strength: ${Math.round(modelData.signalStrength * 100)}%`
                                         color: palette.placeholderText
                                     }
+                                    Label {
+                                        text: `| ${modelData.frequency} MHz`
+                                        color: palette.placeholderText
+                                    }
+                                    Label {
+                                        text: `| BSSID: ${modelData.bssid}`
+                                        color: palette.placeholderText
+                                    }
+                                    Label {
+                                        text: `| Bitrate: ${modelData.maxBitrate} Kbps`
+                                        color: palette.placeholderText
+                                    }
+                                    Label {
+                                        text: `| Bandwidth: ${modelData.bandwidth} MHz`
+                                        color: palette.placeholderText
+                                    }
+                                    Label {
+                                        text: `| Last seen: ${modelData.lastSeen?.toLocaleTimeString() ?? "Never"}`
+                                        color: palette.placeholderText
+                                    }
                                 }
                             }
                             ColumnLayout {

--- a/src/network/wifi.hpp
+++ b/src/network/wifi.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <qdatetime.h>
 #include <qobject.h>
 #include <qproperty.h>
 #include <qqmlintegration.h>
@@ -23,6 +24,16 @@ class WifiNetwork: public Network {
 	Q_PROPERTY(qreal signalStrength READ default NOTIFY signalStrengthChanged BINDABLE bindableSignalStrength);
 	/// The security type of the wifi network.
 	Q_PROPERTY(WifiSecurityType::Enum security READ default NOTIFY securityChanged BINDABLE bindableSecurity);
+	/// The radio frequency of the access point in MHz.
+	Q_PROPERTY(quint32 frequency READ default NOTIFY frequencyChanged BINDABLE bindableFrequency);
+	/// The hardware address (BSSID) of the access point.
+	Q_PROPERTY(QString bssid READ default NOTIFY bssidChanged BINDABLE bindableBssid);
+	/// The maximum bitrate this access point is capable of, in kilobits/second.
+	Q_PROPERTY(quint32 maxBitrate READ default NOTIFY maxBitrateChanged BINDABLE bindableMaxBitrate);
+	/// The channel bandwidth announced by the access point in MHz (e.g. 20, 40, 80, 160).
+	Q_PROPERTY(quint32 bandwidth READ default NOTIFY bandwidthChanged BINDABLE bindableBandwidth);
+	/// The date and time when the access point was last seen in scan results.
+	Q_PROPERTY(QDateTime lastSeen READ default NOTIFY lastSeenChanged BINDABLE bindableLastSeen);
 	// clang-format on
 
 public:
@@ -40,16 +51,31 @@ public:
 
 	QBindable<qreal> bindableSignalStrength() { return &this->bSignalStrength; }
 	QBindable<WifiSecurityType::Enum> bindableSecurity() { return &this->bSecurity; }
+	QBindable<quint32> bindableFrequency() { return &this->bFrequency; }
+	QBindable<QString> bindableBssid() { return &this->bBssid; }
+	QBindable<quint32> bindableMaxBitrate() { return &this->bMaxBitrate; }
+	QBindable<quint32> bindableBandwidth() { return &this->bBandwidth; }
+	QBindable<QDateTime> bindableLastSeen() { return &this->bLastSeen; }
 
 signals:
 	QSDOC_HIDE void requestConnectWithPsk(QString psk);
 	void signalStrengthChanged();
 	void securityChanged();
+	void frequencyChanged();
+	void bssidChanged();
+	void maxBitrateChanged();
+	void bandwidthChanged();
+	void lastSeenChanged();
 
 private:
 	// clang-format off
 	Q_OBJECT_BINDABLE_PROPERTY(WifiNetwork, qreal, bSignalStrength, &WifiNetwork::signalStrengthChanged);
 	Q_OBJECT_BINDABLE_PROPERTY(WifiNetwork, WifiSecurityType::Enum, bSecurity, &WifiNetwork::securityChanged);
+	Q_OBJECT_BINDABLE_PROPERTY(WifiNetwork, quint32, bFrequency, &WifiNetwork::frequencyChanged);
+	Q_OBJECT_BINDABLE_PROPERTY(WifiNetwork, QString, bBssid, &WifiNetwork::bssidChanged);
+	Q_OBJECT_BINDABLE_PROPERTY(WifiNetwork, quint32, bMaxBitrate, &WifiNetwork::maxBitrateChanged);
+	Q_OBJECT_BINDABLE_PROPERTY(WifiNetwork, quint32, bBandwidth, &WifiNetwork::bandwidthChanged);
+	Q_OBJECT_BINDABLE_PROPERTY(WifiNetwork, QDateTime, bLastSeen, &WifiNetwork::lastSeenChanged);
 	// clang-format on
 };
 


### PR DESCRIPTION
### Summary
This PR exposes additional 802.11 access point properties from NetworkManager to `Quickshell.Networking.WifiNetwork`. These properties allow desktop shells to filter networks by frequency band (2.4 GHz vs 5 GHz), and display router MAC addresses and maximum link speeds in network detail views without spawning external CLI tools.

### Added Properties to `WifiNetwork`
* **`frequency`** (`quint32`): The radio frequency in MHz (useful for determining 2.4 GHz, 5 GHz, or 6 GHz bands).
* **`bssid`** (`QString`): The hardware MAC address of the access point.
* **`maxBitrate`** (`quint32`): Maximum bitrate supported by the access point in Kbps.
* **`bandwidth`** (`quint32`): Channel bandwidth announced by the access point in MHz (e.g. 20, 40, 80, 160).
* **`lastSeen`** (`qint32`): Timestamp in `CLOCK_BOOTTIME` seconds when the access point was last seen in scan results.