### PR TITLE
networking: fix omitted mode setting case in NM

### DIFF
--- a/src/network/nm/wireless.cpp
+++ b/src/network/nm/wireless.cpp
@@ -124,7 +124,8 @@ void NMWirelessDevice::onSettingsLoaded(NMSettings* settings) {
 	const auto ssid = map["802-11-wireless"]["ssid"].toString();
 	const auto mode = map["802-11-wireless"]["mode"].toString();
 
-	if (mode == "infrastructure") {
+	// Omitted mode is assumed to be "infrastructure".
+	if (mode.isEmpty() || mode == "infrastructure") {
 		auto* net = this->mNetworks.value(ssid);
 		if (!net) net = this->registerNetwork(ssid);
 		net->addSettings(settings);


### PR DESCRIPTION
Fixes #987. In NetworkManager if the "mode" setting is omitted the default is infrastructure.

Thanks @Awlaursen