### PR TITLE
core: load configs from the vfs mirror to enable the qml disk cache

### DIFF
--- a/changelog/next.md
+++ b/changelog/next.md
@@ -1,3 +1,7 @@
+## Other Changes
+
+- The qml disk cache is now enabled. Config documents are loaded from a mirror in the runtime dir, which is visible in `Component.url` and `Qt.resolvedUrl` results.
+
 ## Bug Fixes
 
 - Fixed main process crashes on pam subprocess misbehavior.

--- a/src/core/generation.cpp
+++ b/src/core/generation.cpp
@@ -34,10 +34,11 @@ QS_LOGGING_CATEGORY(logScene, "scene");
 
 static QHash<const QQmlEngine*, EngineGeneration*> g_generations; // NOLINT
 
-EngineGeneration::EngineGeneration(const QDir& rootPath, QmlScanner scanner)
+EngineGeneration::EngineGeneration(const QDir& rootPath, QmlScanner scanner, QString vfsPath)
     : rootPath(rootPath)
     , scanner(std::move(scanner))
-    , urlInterceptor(this->rootPath)
+    , vfsPath(std::move(vfsPath))
+    , urlInterceptor(this->rootPath, this->vfsPath)
     , interceptNetFactory(this->rootPath, this->scanner.fileIntercepts)
     , engine(new QQmlEngine()) {
 	g_generations.insert(this->engine, this);
@@ -46,7 +47,12 @@ EngineGeneration::EngineGeneration(const QDir& rootPath, QmlScanner scanner)
 	QObject::connect(this->engine, &QQmlEngine::warnings, this, &EngineGeneration::onEngineWarnings);
 
 	this->engine->addUrlInterceptor(&this->urlInterceptor);
-	this->engine->addImportPath("qs:@/");
+
+	if (this->vfsPath.isEmpty()) {
+		this->engine->addImportPath("qs:@/");
+	} else {
+		this->engine->addImportPath(this->vfsPath);
+	}
 
 	this->engine->setNetworkAccessManagerFactory(&this->interceptNetFactory);
 	this->incubationController.initLoop();
@@ -59,7 +65,7 @@ EngineGeneration::EngineGeneration(const QDir& rootPath, QmlScanner scanner)
 	QsEnginePlugin::runConstructGeneration(*this);
 }
 
-EngineGeneration::EngineGeneration(): EngineGeneration(QDir(), QmlScanner()) {}
+EngineGeneration::EngineGeneration(): EngineGeneration(QDir(), QmlScanner(), QString()) {}
 
 EngineGeneration::~EngineGeneration() {
 	for (auto* extension: this->extensions.values()) {
@@ -255,11 +261,9 @@ void EngineGeneration::onDirectoryChanged() {
 	}
 }
 
-void EngineGeneration::onEngineWarnings(const QList<QQmlError>& warnings) {
+void EngineGeneration::onEngineWarnings(const QList<QQmlError>& warnings) const {
 	for (const auto& error: warnings) {
-		const auto& url = error.url();
-		auto rel = url.scheme() == "qs" && url.path().startsWith("@/qs/") ? "@" % url.path().sliced(5)
-		                                                                  : url.toString();
+		auto rel = this->relativeUrl(error.url());
 
 		QString objectName;
 		auto desc = error.description();
@@ -271,6 +275,17 @@ void EngineGeneration::onEngineWarnings(const QList<QQmlError>& warnings) {
 		qCWarning(logScene).noquote().nospace()
 		    << objectName << rel << '[' << error.line() << ':' << error.column() << "]: " << desc;
 	}
+}
+
+QString EngineGeneration::relativeUrl(const QUrl& url) const {
+	if (url.scheme() == "qs" && url.path().startsWith("@/qs/")) return '@' % url.path().sliced(5);
+
+	if (!this->vfsPath.isEmpty() && url.isLocalFile()) {
+		const QString prefix = this->vfsPath % "/qs/";
+		if (url.path().startsWith(prefix)) return '@' % url.path().sliced(prefix.length());
+	}
+
+	return url.toString();
 }
 
 void EngineGeneration::registerExtension(const void* key, EngineGenerationExt* extension) {

--- a/src/core/generation.hpp
+++ b/src/core/generation.hpp
@@ -10,7 +10,9 @@
 #include <qqmlerror.h>
 #include <qqmlincubator.h>
 #include <qquickwindow.h>
+#include <qstring.h>
 #include <qtclasshelpermacros.h>
+#include <qurl.h>
 
 #include "incubator.hpp"
 #include "qsintercept.hpp"
@@ -32,7 +34,7 @@ class EngineGeneration: public QObject {
 
 public:
 	explicit EngineGeneration();
-	explicit EngineGeneration(const QDir& rootPath, QmlScanner scanner);
+	explicit EngineGeneration(const QDir& rootPath, QmlScanner scanner, QString vfsPath);
 	~EngineGeneration() override;
 	Q_DISABLE_COPY_MOVE(EngineGeneration);
 
@@ -47,6 +49,9 @@ public:
 	void registerExtension(const void* key, EngineGenerationExt* extension);
 	EngineGenerationExt* findExtension(const void* key);
 
+	// shortens urls under the config root to the @/ form used in error output
+	[[nodiscard]] QString relativeUrl(const QUrl& url) const;
+
 	static EngineGeneration* findEngineGeneration(const QQmlEngine* engine);
 	static EngineGeneration* findObjectGeneration(const QObject* object);
 
@@ -57,6 +62,7 @@ public:
 	RootWrapper* wrapper = nullptr;
 	QDir rootPath;
 	QmlScanner scanner;
+	QString vfsPath;
 	QsUrlInterceptor urlInterceptor;
 	QsInterceptNetworkAccessManagerFactory interceptNetFactory;
 	QQmlEngine* engine = nullptr;
@@ -85,7 +91,7 @@ private slots:
 	void onFileChanged(const QString& name);
 	void onDirectoryChanged();
 	void onTrackedWindowDestroyed(QObject* object);
-	static void onEngineWarnings(const QList<QQmlError>& warnings);
+	void onEngineWarnings(const QList<QQmlError>& warnings) const;
 
 private:
 	void postReload();

--- a/src/core/qsintercept.cpp
+++ b/src/core/qsintercept.cpp
@@ -48,6 +48,18 @@ QUrl QsUrlInterceptor::intercept(
 			return QUrl("qrc:/qs-blackhole");
 		}
 
+		// Documents must resolve to their vfs path. Qt keys types by intercepted url, so a
+		// second url for the same document means a second compile and singleton instance.
+		if (!this->vfsPath.isEmpty()
+		    && (type != QQmlAbstractUrlInterceptor::DataType::UrlString || path.endsWith(".qml")))
+		{
+			auto newUrl = url;
+			newUrl.setScheme("file");
+			newUrl.setPath(this->toVfsPath(path));
+			qCDebug(logQsIntercept) << "Rewrote intercept" << url << "to" << newUrl;
+			return newUrl;
+		}
+
 		// Some types such as Image take into account where they are loading from, and force
 		// asynchronous loading over a network. qs: is considered to be over a network.
 		// In those cases we want to return a file:// url so asynchronous loading is not forced.
@@ -66,7 +78,33 @@ QUrl QsUrlInterceptor::intercept(
 		}
 	}
 
+	// Real config paths, e.g. from Quickshell.shellDir, are folded in for the same reason.
+	if (!this->vfsPath.isEmpty() && url.scheme() == "file") {
+		auto isDocument =
+		    type == QQmlAbstractUrlInterceptor::DataType::QmlFile
+		    || type == QQmlAbstractUrlInterceptor::DataType::JavaScriptFile
+		    || type == QQmlAbstractUrlInterceptor::DataType::QmldirFile
+		    || (type == QQmlAbstractUrlInterceptor::DataType::UrlString && url.path().endsWith(".qml"));
+
+		if (isDocument) {
+			auto newPath = this->toVfsPath(url.path());
+
+			if (newPath != url.path()) {
+				auto newUrl = url;
+				newUrl.setPath(newPath);
+				qCDebug(logQsIntercept) << "Canonicalized intercept" << url << "to" << newUrl;
+				return newUrl;
+			}
+		}
+	}
+
 	return url;
+}
+
+QString QsUrlInterceptor::toVfsPath(const QString& path) const {
+	const auto& rootPath = this->configRoot.path();
+	if (!path.startsWith(rootPath % '/')) return path;
+	return this->vfsPath % "/qs" % path.sliced(rootPath.length());
 }
 
 QsInterceptDataReply::QsInterceptDataReply(const QString& data, QObject* parent)

--- a/src/core/qsintercept.hpp
+++ b/src/core/qsintercept.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <utility>
+
 #include <qdir.h>
 #include <qhash.h>
 #include <qloggingcategory.h>
@@ -16,12 +18,17 @@ QS_DECLARE_LOGGING_CATEGORY(logQsIntercept);
 
 class QsUrlInterceptor: public QQmlAbstractUrlInterceptor {
 public:
-	explicit QsUrlInterceptor(const QDir& configRoot): configRoot(configRoot) {}
+	explicit QsUrlInterceptor(const QDir& configRoot, QString vfsPath)
+	    : configRoot(configRoot)
+	    , vfsPath(std::move(vfsPath)) {}
 
 	QUrl intercept(const QUrl& originalUrl, QQmlAbstractUrlInterceptor::DataType type) override;
 
 private:
+	[[nodiscard]] QString toVfsPath(const QString& path) const;
+
 	QDir configRoot;
+	QString vfsPath;
 };
 
 class QsInterceptDataReply: public QNetworkReply {

--- a/src/core/rootwrapper.cpp
+++ b/src/core/rootwrapper.cpp
@@ -60,7 +60,7 @@ void RootWrapper::reloadGraph(bool hard) {
 	auto scanner = QmlScanner(rootPath);
 	scanner.scanQmlRoot(this->rootPath);
 
-	qs::core::QmlToolingSupport::updateTooling(rootPath, scanner);
+	qs::core::QmlToolingSupport::updateTooling(rootPath);
 	this->configDirWatcher.addPath(rootPath.path());
 
 	// todo: move into EngineGeneration
@@ -95,12 +95,21 @@ void RootWrapper::reloadGraph(bool hard) {
 		return;
 	}
 
-	auto* generation = new EngineGeneration(rootPath, std::move(scanner));
+	// the qml disk cache only accepts file urls, so load from the vfs mirror when possible
+	auto vfsPath = qs::core::QmlToolingSupport::updateMirror(rootPath, scanner);
+	if (vfsPath.isEmpty()) qWarning() << "Falling back to qs: urls, QML disk cache disabled";
+
+	auto* generation = new EngineGeneration(rootPath, std::move(scanner), vfsPath);
 	generation->wrapper = this;
 
 	QUrl url;
-	url.setScheme("qs");
-	url.setPath("@/qs/" % rootFile.fileName());
+	if (vfsPath.isEmpty()) {
+		url.setScheme("qs");
+		url.setPath("@/qs/" % rootFile.fileName());
+	} else {
+		url = QUrl::fromLocalFile(vfsPath % "/qs/" % rootFile.fileName());
+	}
+
 	auto component = QQmlComponent(generation->engine, url);
 
 	if (!component.isReady()) {
@@ -109,9 +118,7 @@ void RootWrapper::reloadGraph(bool hard) {
 
 		auto errors = component.errors();
 		for (auto& error: errors) {
-			const auto& url = error.url();
-			auto rel = url.scheme() == "qs" && url.path().startsWith("@/qs/") ? "@" % url.path().sliced(5)
-			                                                                  : url.toString();
+			auto rel = generation->relativeUrl(error.url());
 			auto msg = "  caused by " % rel % '[' % QString::number(error.line()) % ':'
 			         % QString::number(error.column()) % "]: " % error.description();
 			errorString += '\n' % msg;
@@ -211,5 +218,6 @@ void RootWrapper::onWatchedFilesChanged() { this->reloadGraph(false); }
 void RootWrapper::updateTooling() {
 	if (!this->generation) return;
 	auto configDir = QFileInfo(this->rootPath).dir();
-	qs::core::QmlToolingSupport::updateTooling(configDir, this->generation->scanner);
+	qs::core::QmlToolingSupport::updateTooling(configDir);
+	qs::core::QmlToolingSupport::updateMirror(configDir, this->generation->scanner);
 }

--- a/src/core/toolsupport.cpp
+++ b/src/core/toolsupport.cpp
@@ -1,15 +1,18 @@
 #include "toolsupport.hpp"
+#include <algorithm>
 #include <cerrno>
 
 #include <fcntl.h>
 #include <qcontainerfwd.h>
 #include <qdebug.h>
 #include <qdir.h>
+#include <qfile.h>
 #include <qfileinfo.h>
 #include <qlist.h>
 #include <qlogging.h>
 #include <qloggingcategory.h>
 #include <qqmlengine.h>
+#include <qset.h>
 #include <qtenvironmentvariables.h>
 
 #include "logcat.hpp"
@@ -22,10 +25,8 @@ namespace {
 QS_LOGGING_CATEGORY(logTooling, "quickshell.tooling", QtWarningMsg);
 }
 
-bool QmlToolingSupport::updateTooling(const QDir& configRoot, QmlScanner& scanner) {
-	auto* vfs = QsPaths::instance()->shellVfsDir();
-
-	if (!vfs) {
+bool QmlToolingSupport::updateTooling(const QDir& configRoot) {
+	if (!QsPaths::instance()->shellVfsDir()) {
 		qCCritical(logTooling) << "Tooling dir could not be created";
 		return false;
 	}
@@ -34,13 +35,129 @@ bool QmlToolingSupport::updateTooling(const QDir& configRoot, QmlScanner& scanne
 		return false;
 	}
 
-	if (!QmlToolingSupport::updateQmllsConfig(configRoot, false)) {
-		QDir(vfs->filePath("qs")).removeRecursively();
+	return QmlToolingSupport::updateQmllsConfig(configRoot, false);
+}
+
+QString QmlToolingSupport::updateMirror(const QDir& configRoot, const QmlScanner& scanner) {
+	auto* vfs = QsPaths::instance()->shellVfsDir();
+	if (!vfs) return QString();
+
+	// the engine canonicalizes import paths, so every url derived from this one must match
+	auto vfsPath = vfs->canonicalPath();
+	if (vfsPath.isEmpty()) return QString();
+	if (!QmlToolingSupport::mirrorDir(scanner, configRoot, vfsPath % "/qs")) return QString();
+
+	return vfsPath;
+}
+
+bool QmlToolingSupport::mirrorDir(
+    const QmlScanner& scanner,
+    const QDir& source,
+    const QString& target
+) {
+	const QString prefix = source.path() % '/';
+
+	auto hasIntercepts = std::any_of(
+	    scanner.fileIntercepts.keyBegin(),
+	    scanner.fileIntercepts.keyEnd(),
+	    [&](const QString& path) { return path.startsWith(prefix); }
+	);
+
+	if (!hasIntercepts) return QmlToolingSupport::linkMirrorEntry(source.path(), target);
+
+	auto targetInfo = QFileInfo(target);
+	if (targetInfo.isSymLink() || (targetInfo.exists() && !targetInfo.isDir())) {
+		QmlToolingSupport::removeMirrorEntry(target);
+	}
+
+	auto targetDir = QDir(target);
+
+	if (!targetDir.mkpath(".")) {
+		qCCritical(logTooling) << "Could not create mirror dir at" << target;
 		return false;
 	}
 
-	QmlToolingSupport::updateToolingFs(scanner, configRoot, vfs->filePath("qs"));
+	QSet<QString> names;
+
+	for (auto [path, text]: scanner.fileIntercepts.asKeyValueRange()) {
+		if (!path.startsWith(prefix)) continue;
+
+		auto name = path.sliced(prefix.length());
+		if (name.contains('/')) continue;
+
+		names.insert(name);
+		if (!QmlToolingSupport::writeMirrorFile(targetDir.filePath(name), text)) return false;
+	}
+
+	auto filters = QDir::AllEntries | QDir::Hidden | QDir::System | QDir::NoDotAndDotDot;
+
+	for (const auto& name: source.entryList(filters)) {
+		if (names.contains(name)) continue;
+		names.insert(name);
+
+		auto path = source.filePath(name);
+		auto entryPath = targetDir.filePath(name);
+		auto ok = QFileInfo(path).isDir() ? QmlToolingSupport::mirrorDir(scanner, QDir(path), entryPath)
+		                                  : QmlToolingSupport::linkMirrorEntry(path, entryPath);
+
+		if (!ok) return false;
+	}
+
+	for (const auto& name: targetDir.entryList(filters)) {
+		if (!names.contains(name)) QmlToolingSupport::removeMirrorEntry(targetDir.filePath(name));
+	}
+
 	return true;
+}
+
+bool QmlToolingSupport::writeMirrorFile(const QString& path, const QString& text) {
+	auto info = QFileInfo(path);
+	if (info.isSymLink() || (info.exists() && !info.isFile())) {
+		QmlToolingSupport::removeMirrorEntry(path);
+	}
+
+	auto file = QFile(path);
+
+	if (!file.open(QFile::ReadWrite)) {
+		qCCritical(logTooling) << "Failed to open mirror file" << path;
+		return false;
+	}
+
+	auto data = text.toUtf8();
+	if (file.readAll() == data) return true;
+
+	if (!file.resize(0) || file.write(data) != data.length()) {
+		qCCritical(logTooling) << "Failed to write mirror file" << path;
+		return false;
+	}
+
+	qCDebug(logTooling) << "Wrote mirror file" << path;
+	return true;
+}
+
+bool QmlToolingSupport::linkMirrorEntry(const QString& path, const QString& linkPath) {
+	auto info = QFileInfo(linkPath);
+	if (info.isSymLink() && info.symLinkTarget() == path) return true;
+
+	QmlToolingSupport::removeMirrorEntry(linkPath);
+
+	if (!QFile::link(path, linkPath)) {
+		qCCritical(logTooling) << "Could not create symlink to" << path << "at" << linkPath;
+		return false;
+	}
+
+	qCDebug(logTooling) << "Created symlink to" << path << "at" << linkPath;
+	return true;
+}
+
+void QmlToolingSupport::removeMirrorEntry(const QString& path) {
+	auto info = QFileInfo(path);
+	if (!info.exists() && !info.isSymLink()) return;
+
+	// isDir follows symlinks, and everything behind one is the real config
+	auto ok =
+	    info.isDir() && !info.isSymLink() ? QDir(path).removeRecursively() : QFile::remove(path);
+	if (!ok) qCWarning(logTooling) << "Failed to remove old file at" << path;
 }
 
 bool QmlToolingSupport::lockTooling() {
@@ -150,96 +267,6 @@ bool QmlToolingSupport::updateQmllsConfig(const QDir& configRoot, bool create) {
 	}
 
 	return true;
-}
-
-void QmlToolingSupport::updateToolingFs(
-    QmlScanner& scanner,
-    const QDir& scanDir,
-    const QDir& linkDir
-) {
-	QList<QString> files;
-	QSet<QString> subdirs;
-
-	auto scanPath = scanDir.path();
-
-	linkDir.mkpath(".");
-
-	for (auto& path: scanner.scannedFiles) {
-		if (path.length() < scanPath.length() + 1 || !path.startsWith(scanPath)) continue;
-		auto name = path.sliced(scanPath.length() + 1);
-
-		if (name.contains('/')) {
-			auto dirname = name.first(name.indexOf('/'));
-			subdirs.insert(dirname);
-			continue;
-		}
-
-		auto fileInfo = QFileInfo(path);
-		if (!fileInfo.isFile()) continue;
-
-		if (scanner.fileIntercepts.contains(path)) continue;
-
-		auto spath = linkDir.filePath(name);
-		auto sFileInfo = QFileInfo(spath);
-
-		if (!sFileInfo.isSymLink() || sFileInfo.symLinkTarget() != path) {
-			QFile::remove(spath);
-
-			if (QFile::link(path, spath)) {
-				qCDebug(logTooling) << "Created symlink to" << path << "at" << spath;
-				files.append(spath);
-			} else {
-				qCCritical(logTooling) << "Could not create symlink to" << path << "at" << spath;
-			}
-		} else {
-			files.append(spath);
-		}
-	}
-
-	for (auto [path, text]: scanner.fileIntercepts.asKeyValueRange()) {
-		if (path.length() < scanPath.length() + 1 || !path.startsWith(scanPath)) continue;
-		auto name = path.sliced(scanPath.length() + 1);
-
-		if (name.contains('/')) {
-			auto dirname = name.first(name.indexOf('/'));
-			subdirs.insert(dirname);
-			continue;
-		}
-
-		auto spath = linkDir.filePath(name);
-		QFile::remove(spath);
-
-		auto file = QFile(spath);
-		if (!file.open(QFile::ReadWrite | QFile::Text | QFile::NewOnly)) {
-			qCCritical(logTooling) << "Failed to open injected file" << spath;
-			continue;
-		}
-
-		if (file.readAll() == text) {
-			files.append(spath);
-			continue;
-		}
-
-		if (file.resize(0) && file.write(text.toUtf8())) {
-			files.append(spath);
-			qCDebug(logTooling) << "Wrote injected file" << spath;
-		} else {
-			qCCritical(logTooling) << "Failed to write injected file" << spath;
-		}
-	}
-
-	for (auto& name: linkDir.entryList(QDir::Files | QDir::System)) { // System = broken symlinks
-		auto path = linkDir.filePath(name);
-
-		if (!files.contains(path)) {
-			if (QFile::remove(path)) qCDebug(logTooling) << "Removed old file at" << path;
-			else qCWarning(logTooling) << "Failed to remove old file at" << path;
-		}
-	}
-
-	for (const auto& subdir: subdirs) {
-		QmlToolingSupport::updateToolingFs(scanner, scanDir.filePath(subdir), linkDir.filePath(subdir));
-	}
 }
 
 } // namespace qs::core

--- a/src/core/toolsupport.cpp
+++ b/src/core/toolsupport.cpp
@@ -1,12 +1,16 @@
 #include "toolsupport.hpp"
-#include <algorithm>
 #include <cerrno>
 
 #include <fcntl.h>
+#include <qbytearray.h>
 #include <qcontainerfwd.h>
+#include <qcryptographichash.h>
+#include <qdatetime.h>
 #include <qdebug.h>
 #include <qdir.h>
+#include <qendian.h>
 #include <qfile.h>
+#include <qfiledevice.h>
 #include <qfileinfo.h>
 #include <qlist.h>
 #include <qlogging.h>
@@ -14,6 +18,7 @@
 #include <qqmlengine.h>
 #include <qset.h>
 #include <qtenvironmentvariables.h>
+#include <qtypes.h>
 
 #include "logcat.hpp"
 #include "paths.hpp"
@@ -45,7 +50,7 @@ QString QmlToolingSupport::updateMirror(const QDir& configRoot, const QmlScanner
 	// the engine canonicalizes import paths, so every url derived from this one must match
 	auto vfsPath = vfs->canonicalPath();
 	if (vfsPath.isEmpty()) return QString();
-	if (!QmlToolingSupport::mirrorDir(scanner, configRoot, vfsPath % "/qs")) return QString();
+	if (!QmlToolingSupport::mirrorDir(scanner, configRoot, QDir(vfsPath % "/qs"))) return QString();
 
 	return vfsPath;
 }
@@ -53,30 +58,19 @@ QString QmlToolingSupport::updateMirror(const QDir& configRoot, const QmlScanner
 bool QmlToolingSupport::mirrorDir(
     const QmlScanner& scanner,
     const QDir& source,
-    const QString& target
+    const QDir& target
 ) {
-	const QString prefix = source.path() % '/';
-
-	auto hasIntercepts = std::any_of(
-	    scanner.fileIntercepts.keyBegin(),
-	    scanner.fileIntercepts.keyEnd(),
-	    [&](const QString& path) { return path.startsWith(prefix); }
-	);
-
-	if (!hasIntercepts) return QmlToolingSupport::linkMirrorEntry(source.path(), target);
-
-	auto targetInfo = QFileInfo(target);
+	auto targetInfo = QFileInfo(target.path());
 	if (targetInfo.isSymLink() || (targetInfo.exists() && !targetInfo.isDir())) {
-		QmlToolingSupport::removeMirrorEntry(target);
+		QmlToolingSupport::removeMirrorEntry(target.path());
 	}
 
-	auto targetDir = QDir(target);
-
-	if (!targetDir.mkpath(".")) {
-		qCCritical(logTooling) << "Could not create mirror dir at" << target;
+	if (!target.mkpath(".")) {
+		qCCritical(logTooling) << "Could not create mirror dir at" << target.path();
 		return false;
 	}
 
+	const QString prefix = source.path() % '/';
 	QSet<QString> names;
 
 	for (auto [path, text]: scanner.fileIntercepts.asKeyValueRange()) {
@@ -86,7 +80,7 @@ bool QmlToolingSupport::mirrorDir(
 		if (name.contains('/')) continue;
 
 		names.insert(name);
-		if (!QmlToolingSupport::writeMirrorFile(targetDir.filePath(name), text)) return false;
+		if (!QmlToolingSupport::writeMirrorFile(target.filePath(name), text.toUtf8())) return false;
 	}
 
 	auto filters = QDir::AllEntries | QDir::Hidden | QDir::System | QDir::NoDotAndDotDot;
@@ -95,22 +89,44 @@ bool QmlToolingSupport::mirrorDir(
 		if (names.contains(name)) continue;
 		names.insert(name);
 
-		auto path = source.filePath(name);
-		auto entryPath = targetDir.filePath(name);
-		auto ok = QFileInfo(path).isDir() ? QmlToolingSupport::mirrorDir(scanner, QDir(path), entryPath)
-		                                  : QmlToolingSupport::linkMirrorEntry(path, entryPath);
-
-		if (!ok) return false;
+		if (!QmlToolingSupport::mirrorEntry(scanner, source.filePath(name), target.filePath(name))) {
+			return false;
+		}
 	}
 
-	for (const auto& name: targetDir.entryList(filters)) {
-		if (!names.contains(name)) QmlToolingSupport::removeMirrorEntry(targetDir.filePath(name));
+	for (const auto& name: target.entryList(filters)) {
+		if (!names.contains(name)) QmlToolingSupport::removeMirrorEntry(target.filePath(name));
 	}
 
 	return true;
 }
 
-bool QmlToolingSupport::writeMirrorFile(const QString& path, const QString& text) {
+bool QmlToolingSupport::mirrorEntry(
+    const QmlScanner& scanner,
+    const QString& path,
+    const QString& target
+) {
+	auto info = QFileInfo(path);
+	auto name = info.fileName();
+
+	// hidden entries can't be modules and .git alone would be thousands of links
+	if (name.startsWith('.')) return QmlToolingSupport::linkMirrorEntry(path, target);
+	if (info.isDir()) return QmlToolingSupport::mirrorDir(scanner, QDir(path), QDir(target));
+
+	auto isDocument = name.endsWith(".qml") || name.endsWith(".js") || name.endsWith(".mjs");
+	if (!isDocument) return QmlToolingSupport::linkMirrorEntry(path, target);
+
+	auto file = QFile(path);
+
+	if (!file.open(QFile::ReadOnly)) {
+		qCWarning(logTooling) << "Could not read" << path << "for the mirror, linking it instead";
+		return QmlToolingSupport::linkMirrorEntry(path, target);
+	}
+
+	return QmlToolingSupport::writeMirrorFile(target, file.readAll());
+}
+
+bool QmlToolingSupport::writeMirrorFile(const QString& path, const QByteArray& data) {
 	auto info = QFileInfo(path);
 	if (info.isSymLink() || (info.exists() && !info.isFile())) {
 		QmlToolingSupport::removeMirrorEntry(path);
@@ -123,15 +139,25 @@ bool QmlToolingSupport::writeMirrorFile(const QString& path, const QString& text
 		return false;
 	}
 
-	auto data = text.toUtf8();
-	if (file.readAll() == data) return true;
+	if (file.readAll() != data) {
+		if (!file.resize(0) || file.write(data) != data.length() || !file.flush()) {
+			qCCritical(logTooling) << "Failed to write mirror file" << path;
+			return false;
+		}
 
-	if (!file.resize(0) || file.write(data) != data.length()) {
-		qCCritical(logTooling) << "Failed to write mirror file" << path;
+		qCDebug(logTooling) << "Wrote mirror file" << path;
+	}
+
+	// Qt validates cache entries by source mtime, which is always 1 in the nix store, so the
+	// mtime is derived from content instead. Spans 2000..2030 as a zero stamp disables the check.
+	auto hash = QCryptographicHash::hash(data, QCryptographicHash::Md5);
+	auto secs = 946684800 + qFromBigEndian<quint32>(hash.constData()) % 946684800;
+
+	if (!file.setFileTime(QDateTime::fromSecsSinceEpoch(secs), QFile::FileModificationTime)) {
+		qCCritical(logTooling) << "Failed to set mirror file time on" << path;
 		return false;
 	}
 
-	qCDebug(logTooling) << "Wrote mirror file" << path;
 	return true;
 }
 

--- a/src/core/toolsupport.hpp
+++ b/src/core/toolsupport.hpp
@@ -8,13 +8,17 @@ namespace qs::core {
 
 class QmlToolingSupport {
 public:
-	static bool updateTooling(const QDir& configRoot, QmlScanner& scanner);
+	static bool updateTooling(const QDir& configRoot);
+	static QString updateMirror(const QDir& configRoot, const QmlScanner& scanner);
 
 private:
 	static QString getQmllsConfig();
 	static bool lockTooling();
 	static bool updateQmllsConfig(const QDir& configRoot, bool create);
-	static void updateToolingFs(QmlScanner& scanner, const QDir& scanDir, const QDir& linkDir);
+	static bool mirrorDir(const QmlScanner& scanner, const QDir& source, const QString& target);
+	static bool writeMirrorFile(const QString& path, const QString& text);
+	static bool linkMirrorEntry(const QString& path, const QString& linkPath);
+	static void removeMirrorEntry(const QString& path);
 	static inline bool toolingEnabled = false;
 	static inline QFile* toolingLock = nullptr;
 };

--- a/src/core/toolsupport.hpp
+++ b/src/core/toolsupport.hpp
@@ -15,8 +15,9 @@ private:
 	static QString getQmllsConfig();
 	static bool lockTooling();
 	static bool updateQmllsConfig(const QDir& configRoot, bool create);
-	static bool mirrorDir(const QmlScanner& scanner, const QDir& source, const QString& target);
-	static bool writeMirrorFile(const QString& path, const QString& text);
+	static bool mirrorDir(const QmlScanner& scanner, const QDir& source, const QDir& target);
+	static bool mirrorEntry(const QmlScanner& scanner, const QString& path, const QString& target);
+	static bool writeMirrorFile(const QString& path, const QByteArray& data);
 	static bool linkMirrorEntry(const QString& path, const QString& linkPath);
 	static void removeMirrorEntry(const QString& path);
 	static inline bool toolingEnabled = false;

--- a/src/launch/launch.cpp
+++ b/src/launch/launch.cpp
@@ -230,7 +230,7 @@ int launch(const LaunchArgs& args, char** argv) {
 		}
 	}
 
-	// The qml engine currently refuses to cache non file (qsintercept) paths.
+	// The qml engine only caches file urls, so configs are loaded from the vfs mirror.
 
 	// if (auto* cacheDir = QsPaths::instance()->cacheDir()) {
 	// 	auto qmlCacheDir = cacheDir->filePath("qml-engine-cache");


### PR DESCRIPTION
As noted in the codebase and #735, the QML disk cache doesnt work with `qs:` URLs.

This makes `vfs/<id>/qs` the import root and mirrors the full config there. Normal dirs are symlinked directly; dirs with generated files like `qmldir`, `//@ if`, or `qml.json` are mirrored with symlinks plus the generated files. Generated files are only rewritten when their contents change so cache mtimes stay valid.

The URL interceptor also canonicalizes config QML/JS/qmldir paths into the mirror so the same document cant be loaded under both `qs:` and `file:` URLs.

If the VFS cant be created it falls back to `qs:` like before.

On DMS this drops warm launch to "Configuration Loaded" from 1.28s to 0.77s and RSS by ~40MB.

Verify with `QT_LOGGING_RULES=qt.qml.diskcache=true`; the second run should be silent.
