### PR TITLE
core: load shell translation catalogs

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -58,6 +58,10 @@ svg icons will not work, including system ones.
 
 At least Qt 6.6 is required.
 
+Developer builds with `-DBUILD_TESTING=ON` also require Qt Linguist Tools
+(`lrelease`) to compile translation test catalogs. This is not a runtime
+dependency or a requirement for builds with testing disabled.
+
 All features are enabled by default and some have their own dependencies.
 
 ### Crash Handler

--- a/changelog/next.md
+++ b/changelog/next.md
@@ -1,3 +1,10 @@
+## Features
+
+- Added shell translation catalogs in `i18n/qml_<language>.qm`, with runtime
+  language switching through `Qt.uiLanguage`. Place compiled Qt Linguist catalogs
+  beside the root QML file in `i18n/` and use `qsTr()` in translation bindings.
+  Reload the shell after updating catalogs.
+
 ## Bug Fixes
 
 - Fixed main process crashes on pam subprocess misbehavior.

--- a/shell.nix
+++ b/shell.nix
@@ -19,6 +19,7 @@ in pkgs.mkShell.override { stdenv = quickshell.stdenv; } {
     clang-tools
     parallel
     makeWrapper
+    qt6.qttools # lrelease for translation test catalogs
   ];
 
   TIDYFOX = "${tidyfox}/lib/libtidyfox.so";

--- a/src/core/rootwrapper.cpp
+++ b/src/core/rootwrapper.cpp
@@ -2,9 +2,11 @@
 #include <cstdlib>
 #include <utility>
 
+#include <qcoreapplication.h>
 #include <qdir.h>
 #include <qfileinfo.h>
 #include <qfilesystemwatcher.h>
+#include <qlocale.h>
 #include <qlogging.h>
 #include <qobject.h>
 #include <qqmlcomponent.h>
@@ -48,10 +50,27 @@ RootWrapper::RootWrapper(QString rootPath, QString shellId)
 }
 
 RootWrapper::~RootWrapper() {
+	QObject::disconnect(this->translationLanguageConnection);
 	// event loop may no longer be running so deleteLater is not an option
 	if (this->generation != nullptr) {
 		this->generation->shutdown();
 	}
+	QCoreApplication::removeTranslator(&this->translator);
+}
+
+void RootWrapper::updateTranslations(QQmlEngine* engine) {
+	QCoreApplication::removeTranslator(&this->translator);
+	if (!engine->uiLanguage().isEmpty()
+	    && this->translator.load(
+	        QLocale(engine->uiLanguage()),
+	        "qml",
+	        "_",
+	        QFileInfo(this->rootPath).dir().filePath("i18n")
+	    ))
+	{
+		QCoreApplication::installTranslator(&this->translator);
+	}
+	engine->retranslate();
 }
 
 void RootWrapper::reloadGraph(bool hard) {
@@ -143,6 +162,19 @@ void RootWrapper::reloadGraph(bool hard) {
 
 		return;
 	}
+
+	// Do not replace the running shell's translator or connection until compilation succeeds.
+	// Install before creating objects so imperative translations during startup work too.
+	auto* engine = generation->engine;
+	engine->setUiLanguage(
+	    this->generation ? this->generation->engine->uiLanguage() : QLocale().uiLanguages().value(0)
+	);
+	QObject::disconnect(this->translationLanguageConnection);
+	this->translationLanguageConnection =
+	    QObject::connect(engine, &QQmlEngine::uiLanguageChanged, this, [this, engine]() {
+		    this->updateTranslations(engine);
+	    });
+	this->updateTranslations(engine);
 
 	auto* newRoot = component.beginCreate(generation->engine->rootContext());
 

--- a/src/core/rootwrapper.hpp
+++ b/src/core/rootwrapper.hpp
@@ -5,6 +5,7 @@
 #include <qqmlengine.h>
 #include <qtclasshelpermacros.h>
 #include <qtmetamacros.h>
+#include <qtranslator.h>
 #include <qurl.h>
 
 #include "generation.hpp"
@@ -26,9 +27,14 @@ private slots:
 	void updateTooling();
 
 private:
+	void updateTranslations(QQmlEngine* engine);
+
 	QString rootPath;
 	QString shellId;
 	EngineGeneration* generation = nullptr;
 	QString originalWorkingDirectory;
 	QFileSystemWatcher configDirWatcher;
+	// Keep one catalog across overlapping engine generations. Qt translators are process-wide.
+	QTranslator translator;
+	QMetaObject::Connection translationLanguageConnection;
 };

--- a/src/core/test/CMakeLists.txt
+++ b/src/core/test/CMakeLists.txt
@@ -9,3 +9,19 @@ qs_test(ringbuffer ringbuf.cpp)
 qs_test(scriptmodel scriptmodel.cpp)
 qs_test(stacklist stacklist.cpp)
 qs_test(objectmodel objectmodel.cpp)
+
+# Exercise translation loading in the real shell.
+find_package(Qt6 REQUIRED COMPONENTS LinguistTools)
+add_executable(translations translations.cpp)
+target_link_libraries(translations PRIVATE Qt::Core Qt::Test)
+target_compile_definitions(translations PRIVATE QS_BINARY="$<TARGET_FILE:quickshell>")
+add_dependencies(translations quickshell)
+add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/qml_ru.qm"
+	COMMAND Qt6::lrelease "${CMAKE_CURRENT_SOURCE_DIR}/translations/qml_ru.ts"
+		-qm "${CMAKE_CURRENT_BINARY_DIR}/qml_ru.qm"
+	DEPENDS "translations/qml_ru.ts"
+	VERBATIM
+)
+target_sources(translations PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/qml_ru.qm")
+add_test(NAME translations WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}" COMMAND translations)
+set_tests_properties(translations PROPERTIES TIMEOUT 30)

--- a/src/core/test/translations.cpp
+++ b/src/core/test/translations.cpp
@@ -1,0 +1,46 @@
+#include "translations.hpp"
+
+#include <qdir.h>
+#include <qfile.h>
+#include <qprocess.h>
+#include <qtemporarydir.h>
+#include <qtest.h>
+#include <qtestcase.h>
+
+void TestTranslations::catalogAndLanguageSwitch() {
+	const QTemporaryDir directory;
+	QVERIFY(directory.isValid());
+	auto root = QDir(directory.path());
+	QVERIFY(root.mkdir("i18n"));
+
+	QVERIFY(QFile::copy(QFINDTESTDATA("translations/shell.qml"), root.filePath("shell.qml")));
+	QVERIFY(QFile::copy("qml_ru.qm", root.filePath("i18n/qml_ru.qm")));
+
+	auto environment = QProcessEnvironment::systemEnvironment();
+	environment.insert("QT_QPA_PLATFORM", "offscreen");
+	environment.insert("QT_QPA_PLATFORMTHEME", "generic");
+	environment.insert("LC_ALL", "C.UTF-8");
+	environment.insert("LANGUAGE", "ru_RU");
+	environment.insert("QS_DISABLE_FILE_WATCHER", "1");
+	environment.insert("XDG_RUNTIME_DIR", root.path());
+	environment.insert("XDG_CACHE_HOME", root.filePath("cache"));
+	environment.insert("XDG_STATE_HOME", root.filePath("state"));
+	environment.insert("XDG_DATA_HOME", root.filePath("data"));
+	environment.remove("WAYLAND_DISPLAY");
+
+	QProcess shell;
+	shell.setProcessEnvironment(environment);
+	shell.setProcessChannelMode(QProcess::MergedChannels);
+	shell.start(QS_BINARY, {"-p", root.filePath("shell.qml")});
+	auto finished = shell.waitForFinished(10000);
+	if (!finished) {
+		shell.kill();
+		shell.waitForFinished(3000);
+	}
+	auto output = shell.readAll();
+	QVERIFY2(finished, output.constData());
+	QCOMPARE(shell.exitStatus(), QProcess::NormalExit);
+	QVERIFY2(shell.exitCode() == 0, output.constData());
+}
+
+QTEST_GUILESS_MAIN(TestTranslations);

--- a/src/core/test/translations.hpp
+++ b/src/core/test/translations.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <qobject.h>
+#include <qtmetamacros.h>
+
+class TestTranslations: public QObject {
+	Q_OBJECT;
+
+private slots:
+	static void catalogAndLanguageSwitch();
+};

--- a/src/core/test/translations/qml_ru.ts
+++ b/src/core/test/translations/qml_ru.ts
@@ -1,0 +1,14 @@
+<TS version="2.1" language="ru_RU">
+<context>
+    <name>shell</name>
+    <message><source>Hello</source><translation>Привет</translation></message>
+    <message numerus="yes">
+        <source>%n file(s)</source>
+        <translation>
+            <numerusform>%n файл</numerusform>
+            <numerusform>%n файла</numerusform>
+            <numerusform>%n файлов</numerusform>
+        </translation>
+    </message>
+</context>
+</TS>

--- a/src/core/test/translations/shell.qml
+++ b/src/core/test/translations/shell.qml
@@ -1,0 +1,30 @@
+import QtQuick
+import Quickshell
+
+ShellRoot {
+    id: root
+    property string greeting: qsTr("Hello")
+    property string initialGreeting
+    property int count: 1
+    property string files: qsTr("%n file(s)", "", count)
+    Component.onCompleted: initialGreeting = qsTr("Hello")
+
+    Timer {
+        interval: 1
+        running: true
+        onTriggered: {
+            let ok = root.greeting === "Привет" && root.initialGreeting === "Привет";
+            ok = ok && root.files === "1 файл";
+            root.count = 2;
+            ok = ok && root.files === "2 файла";
+            root.count = 5;
+            ok = ok && root.files === "5 файлов";
+            Qt.uiLanguage = "";
+            ok = ok && root.greeting === "Hello";
+            Qt.uiLanguage = "ru_RU";
+            ok = ok && root.greeting === "Привет" && root.files === "5 файлов";
+            if (!ok) console.error("Translation checks failed");
+            Qt.exit(ok ? 0 : 1);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Allow applications built with Quickshell to translate their UI using Qt's standard translation system. For example, an Omarchy plugin's strings can be included in the shell's translation catalog.

Without built-in catalog loading, applications need extra integration, such as a C++ QML extension that installs a `QTranslator`. I tried this in an earlier PoC, but it leaves the application responsible for building and distributing the extension and handling engine reloads. This change handles catalog loading in Quickshell itself.

Load `i18n/qml_<language>.qm` beside the root QML file, following the `QQmlApplicationEngine` naming convention. Applications can use `qsTr()` and other standard Qt translation APIs, with Qt handling plural forms and translation contexts. Set `Qt.uiLanguage` to switch languages.

One `QTranslator` is owned by `RootWrapper` across engine reloads, so catalogs from overlapping generations do not mix. Language changes replace the catalog and call `retranslate()`. Reloads preserve the selected language and load translations before QML object creation. Failed QML compilation leaves the running shell's translator intact.

Related to #445.

## Testing

- Built with Qt 6.11.2 and Clang 22.1.8, with tests enabled, PCH disabled and the crash handler disabled.
- Added one integration test covering startup translation, Russian plural forms, language switching and source-text fallback.
- The full suite passes 9 of 10 test targets. `popupwindow::moveWithParent` fails with the offscreen platform; the same failure was reproduced with the original source during earlier verification.
- Formatting checks and clang-tidy on the new test pass. Earlier comparison of clang-tidy diagnostics for `rootwrapper.cpp` found identical warnings in unchanged headers before and after this change.
- Qt 6.6, Nix, upstream CI and tidyfox have not been verified locally.

Test QML and translation data are separate fixtures. Qt Linguist Tools (`lrelease`) are required for test builds only; no runtime dependency is added.

## Scope

One catalog per shell. Updating a catalog requires an explicit shell reload. Per-plugin catalogs, RTL layout and OS locale settings are outside this change.

Developed with AI assistance.
