### PR TITLE
wayland/screencopy: bind transform query wl_output with a private listener

### DIFF
--- a/src/wayland/screencopy/wlr_screencopy/wlr_screencopy.cpp
+++ b/src/wayland/screencopy/wlr_screencopy/wlr_screencopy.cpp
@@ -8,8 +8,8 @@
 #include <qobject.h>
 #include <qscreen.h>
 #include <qtmetamacros.h>
-#include <qtypes.h>
 #include <qwaylandclientextension.h>
+#include <wayland-client-protocol.h>
 #include <wayland-wlr-screencopy-unstable-v1-client-protocol.h>
 
 #include "../../../core/logcat.hpp"
@@ -161,8 +161,12 @@ void WlrScreencopyContext::submitFrame() {
 WlrScreencopyContext::OutputTransformQuery::OutputTransformQuery(WlrScreencopyContext* context)
     : context(context) {}
 
-WlrScreencopyContext::OutputTransformQuery::~OutputTransformQuery() {
-	if (this->isInitialized()) this->release();
+WlrScreencopyContext::OutputTransformQuery::~OutputTransformQuery() { this->release(); }
+
+void WlrScreencopyContext::OutputTransformQuery::release() {
+	if (this->output == nullptr) return;
+	wl_output_release(this->output);
+	this->output = nullptr;
 }
 
 void WlrScreencopyContext::OutputTransformQuery::setScreen(
@@ -174,28 +178,73 @@ void WlrScreencopyContext::OutputTransformQuery::setScreen(
 		[[nodiscard]] int globalId() const { return this->m_outputId; }
 	};
 
-	if (this->isInitialized()) this->release();
+	this->release();
 
-	this->init(
+	// Bound by hand, with our own listener: see the class comment.
+	this->output = static_cast<::wl_output*>(wl_registry_bind(
 	    screen->display()->wl_registry(),
 	    static_cast<QWaylandScreenReflector*>(screen)->globalId(), // NOLINT
+	    &wl_output_interface,
 	    3
-	);
+	));
+
+	wl_output_add_listener(this->output, &LISTENER, this);
 }
 
-void WlrScreencopyContext::OutputTransformQuery::output_geometry(
-    qint32 /*x*/,
-    qint32 /*y*/,
-    qint32 /*width*/,
-    qint32 /*height*/,
-    qint32 /*subpixel*/,
-    const QString& /*make*/,
-    const QString& /*model*/,
-    qint32 transform
+const wl_output_listener WlrScreencopyContext::OutputTransformQuery::LISTENER = {
+    .geometry = &OutputTransformQuery::onGeometry,
+    .mode = &OutputTransformQuery::onMode,
+    .done = &OutputTransformQuery::onDone,
+    .scale = &OutputTransformQuery::onScale,
+    .name = &OutputTransformQuery::onName,
+    .description = &OutputTransformQuery::onDescription,
+};
+
+void WlrScreencopyContext::OutputTransformQuery::onGeometry(
+    void* data,
+    ::wl_output* /*output*/,
+    int32_t /*x*/,
+    int32_t /*y*/,
+    int32_t /*physicalWidth*/,
+    int32_t /*physicalHeight*/,
+    int32_t /*subpixel*/,
+    const char* /*make*/,
+    const char* /*model*/,
+    int32_t transform
 ) {
-	auto newTransform = this->transform == -1;
-	this->transform = transform;
-	this->context->updateTransform(newTransform);
+	auto* self = static_cast<OutputTransformQuery*>(data);
+	auto newTransform = self->transform == -1;
+	self->transform = transform;
+	self->context->updateTransform(newTransform);
 }
+
+void WlrScreencopyContext::OutputTransformQuery::onMode(
+    void* /*data*/,
+    ::wl_output* /*output*/,
+    uint32_t /*flags*/,
+    int32_t /*width*/,
+    int32_t /*height*/,
+    int32_t /*refresh*/
+) {}
+
+void WlrScreencopyContext::OutputTransformQuery::onDone(void* /*data*/, ::wl_output* /*output*/) {}
+
+void WlrScreencopyContext::OutputTransformQuery::onScale(
+    void* /*data*/,
+    ::wl_output* /*output*/,
+    int32_t /*factor*/
+) {}
+
+void WlrScreencopyContext::OutputTransformQuery::onName(
+    void* /*data*/,
+    ::wl_output* /*output*/,
+    const char* /*name*/
+) {}
+
+void WlrScreencopyContext::OutputTransformQuery::onDescription(
+    void* /*data*/,
+    ::wl_output* /*output*/,
+    const char* /*description*/
+) {}
 
 } // namespace qs::wayland::screencopy::wlr

--- a/src/wayland/screencopy/wlr_screencopy/wlr_screencopy_p.hpp
+++ b/src/wayland/screencopy/wlr_screencopy/wlr_screencopy_p.hpp
@@ -6,6 +6,7 @@
 #include <qtclasshelpermacros.h>
 #include <qtypes.h>
 #include <qwayland-wlr-screencopy-unstable-v1.h>
+#include <wayland-client-protocol.h>
 
 #include "../manager.hpp"
 
@@ -45,29 +46,41 @@ private slots:
 private:
 	void submitFrame();
 
-	class OutputTransformQuery: public QtWayland::wl_output {
+	// Learns the output transform from wl_output.geometry on a private bind.
+	// QtWayland does not retain it: QWaylandScreen consumes mTransform in
+	// updateOutputProperties() and QScreen::orientation() drops flipped variants.
+	//
+	// The proxy deliberately does not use Qt's generated QtWayland::wl_output.
+	// Compositors send wl_surface.enter for every wl_output resource a client
+	// holds, and QWaylandScreen::fromWlOutput() decides whether an output is one
+	// of its own screens purely by the proxy's listener - so a proxy carrying
+	// Qt's listener ends up in QWaylandSurface::m_screens as a fake QWaylandScreen
+	// and is dereferenced after this object is gone. (quickshell#1094)
+	class OutputTransformQuery {
 	public:
-		OutputTransformQuery(WlrScreencopyContext* context);
-		~OutputTransformQuery() override;
+		explicit OutputTransformQuery(WlrScreencopyContext* context);
+		~OutputTransformQuery();
 		Q_DISABLE_COPY_MOVE(OutputTransformQuery);
 
 		qint32 transform = -1;
 		void setScreen(QtWaylandClient::QWaylandScreen* screen);
 
-	protected:
-		void output_geometry(
-		    qint32 x,
-		    qint32 y,
-		    qint32 width,
-		    qint32 height,
-		    qint32 subpixel,
-		    const QString& make,
-		    const QString& model,
-		    qint32 transform
-		) override;
-
 	private:
+		void release();
+
+		// clang-format off
+		static void onGeometry(void* data, ::wl_output* output, int32_t x, int32_t y, int32_t physicalWidth, int32_t physicalHeight, int32_t subpixel, const char* make, const char* model, int32_t transform);
+		static void onMode(void* data, ::wl_output* output, uint32_t flags, int32_t width, int32_t height, int32_t refresh);
+		static void onDone(void* data, ::wl_output* output);
+		static void onScale(void* data, ::wl_output* output, int32_t factor);
+		static void onName(void* data, ::wl_output* output, const char* name);
+		static void onDescription(void* data, ::wl_output* output, const char* description);
+		// clang-format on
+
+		static const wl_output_listener LISTENER;
+
 		WlrScreencopyContext* context;
+		::wl_output* output = nullptr;
 	};
 
 	WlrScreencopyManager* manager;


### PR DESCRIPTION
## What was wrong

`WlrScreencopyContext::OutputTransformQuery` binds a second `wl_output` for the captured screen to learn its transform, and did so through Qt's generated `QtWayland::wl_output`, i.e. with Qt's own `m_wl_output_listener` on the proxy. Compositors send `wl_surface.enter` for every `wl_output` resource a client holds (smithay and wlroots both do), and `QWaylandScreen::fromWlOutput()` decides whether an output is one of its screens purely by comparing that listener. So it accepted our proxy, `static_cast` the `OutputTransformQuery` to a `QWaylandScreen` and appended the result to `QWaylandSurface::m_screens`. A `release()`d proxy never receives `leave`, so the entry outlived the context and was dereferenced on the next `screensChanged` — `QPlatformScreen::screen()` on freed memory, whole shell down.

## The fix

Keep the extra bind, but do it by hand (`wl_registry_bind` + a private `wl_output_listener`), so `fromObject()` rejects the proxy and `surface_enter()` ignores it. No behaviour change otherwise: `transform` is still read from `wl_output.geometry`, `updateTransform()` / `submitFrame()` are untouched.

Reading `QWaylandScreen::mTransform` through the existing reflector instead (no second bind at all) was tried first and does not work: Qt resets it to `-1` in `updateOutputProperties()`, and `QScreen::orientation()` drops the flipped transforms. That variant produced an unrotated capture on a `transform 90` output.

## Verification (niri 26.04, Qt 6.11.2)

- Deterministic reproducer from #1094: crashed on the first hide 3/3 before, runs to completion 3/3 after. `WAYLAND_DEBUG` still shows the second bind and the duplicate `enter` — now harmless.
- Capture on a normal output: matches `dms screenshot` of the same moment (RMSE 0.013 at 480px).
- Capture on the same output rotated to `transform 90`: 2160×3840, upright, matches the reference (the mTransform variant did not).
- Builds clean on `master` and on v0.3.1; `clang-format` clean.

## Disclosure

To be upfront: I am not really familiar with Qt or C++, and this code was written entirely by an AI assistant working with me — the analysis in #1094, the reproducer, the patch and the verification all came out of that session. If anything here is wrong, unidiomatic, or simply not how you would want it done, please say so; I am happy to rework it however you prefer. What I can vouch for is that it fixes the crash on my machine.

I am aware this is not a great fix. It keeps the original "cursed hack" intact — a second `wl_output` bind per capture, and a reflector subclass poking at `QWaylandScreen`'s protected `m_outputId` to know which global to bind — and only changes whose listener the proxy carries. It removes the crash without removing the reason the hack exists: QtWayland does not expose the raw output transform anywhere (`mTransform` is transient, `QScreen::orientation()` drops flips). If there is a better way to get at the transform without a second bind or private Qt state, I would much rather do that — please say so and I will rework it.

Fix #1094 